### PR TITLE
JuceTesting shows that all signalhandling should be installed per thread

### DIFF
--- a/src/stacktrace_windows.hpp
+++ b/src/stacktrace_windows.hpp
@@ -17,6 +17,8 @@
 #error "stacktrace_win.cpp used but not on a windows system"
 #endif
 
+#define g2_thread_local __declspec(thread) 
+
 #include <string>
 #include <windows.h>
 #include "crashhandler.hpp"


### PR DESCRIPTION
From: https://github.com/KjellKod/JuceApp

Im clueless as to why this is needed in JuceApp but not in my fatal example. Either way. it doesn't hurt to do it this way. 