### PR TITLE
Windows vector exceptions

### DIFF
--- a/example/main_fatal_choice.cpp
+++ b/example/main_fatal_choice.cpp
@@ -233,10 +233,18 @@ void ChooseFatalExit() {
 }
 } // namespace
 
+void breakHere() {
+ #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
+   __debugbreak(); 
+ #endif
+}
+
 int main(int argc, char** argv)
 {
    auto logger_n_handle = g2::LogWorker::createWithDefaultLogger(argv[0], path_to_log_file);
    g2::initializeLogging(logger_n_handle.worker.get());
+   g2::setFatalPreLoggingHook(&breakHere);
+
    std::future<std::string> log_file_name = logger_n_handle.sink->call(&g2::FileSink::fileName);
    std::cout << "**** G3LOG FATAL EXAMPLE ***\n\n"
              << "Choose your type of fatal exit, then "

--- a/src/crashhandler_windows.cpp
+++ b/src/crashhandler_windows.cpp
@@ -30,7 +30,7 @@ std::atomic<bool> gBlockForFatal {true};
 LPTOP_LEVEL_EXCEPTION_FILTER g_previous_unexpected_exception_handler = nullptr;
 
 #if !(defined(DISABLE_FATAL_SIGNALHANDLING))
-g2_thread_local bool g_installed_thread_signal_handler = false;
+thread_local bool g_installed_thread_signal_handler = false;
 #endif
 
 #if !(defined(DISABLE_VECTORED_EXCEPTIONHANDLING))

--- a/src/g2log.hpp
+++ b/src/g2log.hpp
@@ -33,6 +33,16 @@
 #define __PRETTY_FUNCTION__   __FUNCTION__
 #endif
 
+
+// thread_local doesn't exist on VS2013 but it might soon? (who knows)
+// to avoid future issues, let's define g2_thread_local that should continue
+// to work after Microsoft has updated to be C++11 compliant
+#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
+#define g2_thread_local __declspec(thread) 
+#else 
+#define g2_thread_local thread_local
+#endif
+
 /** namespace for LOG() and CHECK() frameworks
  * History lesson:   Why the names 'g2' and 'g2log'?:
  * The framework was made in my own free time as PUBLIC DOMAIN but the 
@@ -62,8 +72,8 @@ namespace g2 {
    * This will be reset to default (does nothing) at initializeLogging(...);
    *
    * Example usage:
-   * Windows: g2::SetPreFatalHook([]{__debugbreak();}); // remember #include <intrin.h>
-   * Linux:   g2::SetPreFatalHook([]{ raise(SIGTRAP); }); 
+   * Windows: g2::setFatalPreLoggingHook([]{__debugbreak();}); // remember #include <intrin.h>
+   * Linux:   g2::setFatalPreLoggingHook([]{ raise(SIGTRAP); }); 
    */
    void setFatalPreLoggingHook(std::function<void(void)>  pre_fatal_hook);
 

--- a/src/g2log.hpp
+++ b/src/g2log.hpp
@@ -33,15 +33,12 @@
 #define __PRETTY_FUNCTION__   __FUNCTION__
 #endif
 
-
 // thread_local doesn't exist on VS2013 but it might soon? (who knows)
-// to avoid future issues, let's define g2_thread_local that should continue
 // to work after Microsoft has updated to be C++11 compliant
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
-#define g2_thread_local __declspec(thread) 
-#else 
-#define g2_thread_local thread_local
-#endif
+#if !(defined(thread_local)) && (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
+#define thread_local __declspec(thread) 
+#endif 
+
 
 /** namespace for LOG() and CHECK() frameworks
  * History lesson:   Why the names 'g2' and 'g2log'?:

--- a/src/g2log.hpp
+++ b/src/g2log.hpp
@@ -73,6 +73,10 @@ namespace g2 {
    *
    * Example usage:
    * Windows: g2::setFatalPreLoggingHook([]{__debugbreak();}); // remember #include <intrin.h>
+   *         WARNING: '__debugbreak()' when not running in Debug in your Visual Studio IDE will likely
+   *                   trigger a recursive crash if used here. It should only be used when debugging
+   *                   in your Visual Studio IDE. Recursive crashes are handled but are unnecessary.
+   *
    * Linux:   g2::setFatalPreLoggingHook([]{ raise(SIGTRAP); }); 
    */
    void setFatalPreLoggingHook(std::function<void(void)>  pre_fatal_hook);

--- a/src/stacktrace_windows.cpp
+++ b/src/stacktrace_windows.cpp
@@ -35,7 +35,7 @@
 #define g2_MAP_PAIR_STRINGIFY(x) {x, #x}
 
 namespace {
-g2_thread_local size_t g_thread_local_recursive_crash_check = 0;
+thread_local size_t g_thread_local_recursive_crash_check = 0;
 
 const std::map<g2::SignalType, std::string> kExceptionsAsText = {
    g2_MAP_PAIR_STRINGIFY(EXCEPTION_ACCESS_VIOLATION)

--- a/src/stacktrace_windows.cpp
+++ b/src/stacktrace_windows.cpp
@@ -13,6 +13,7 @@
  * ============================================================================*/
 
 #include "stacktrace_windows.hpp"
+#include "g2log.hpp"
 #include <windows.h>
 #include <DbgHelp.h>
 #include <map>
@@ -39,7 +40,6 @@ g2_thread_local size_t g_thread_local_recursive_crash_check = 0;
 const std::map<g2::SignalType, std::string> kExceptionsAsText = {
    g2_MAP_PAIR_STRINGIFY(EXCEPTION_ACCESS_VIOLATION)
    , g2_MAP_PAIR_STRINGIFY(EXCEPTION_ARRAY_BOUNDS_EXCEEDED)
-   , g2_MAP_PAIR_STRINGIFY(EXCEPTION_BREAKPOINT)
    , g2_MAP_PAIR_STRINGIFY(EXCEPTION_DATATYPE_MISALIGNMENT)
    , g2_MAP_PAIR_STRINGIFY(EXCEPTION_FLT_DENORMAL_OPERAND)
    , g2_MAP_PAIR_STRINGIFY(EXCEPTION_FLT_DIVIDE_BY_ZERO)
@@ -56,8 +56,10 @@ const std::map<g2::SignalType, std::string> kExceptionsAsText = {
    , g2_MAP_PAIR_STRINGIFY(EXCEPTION_INVALID_DISPOSITION)
    , g2_MAP_PAIR_STRINGIFY(EXCEPTION_NONCONTINUABLE_EXCEPTION)
    , g2_MAP_PAIR_STRINGIFY(EXCEPTION_PRIV_INSTRUCTION)
-   , g2_MAP_PAIR_STRINGIFY(EXCEPTION_SINGLE_STEP)
    , g2_MAP_PAIR_STRINGIFY(EXCEPTION_STACK_OVERFLOW)
+   , g2_MAP_PAIR_STRINGIFY(EXCEPTION_BREAKPOINT)
+   , g2_MAP_PAIR_STRINGIFY(EXCEPTION_SINGLE_STEP)
+
 };
 
 

--- a/src/stacktrace_windows.hpp
+++ b/src/stacktrace_windows.hpp
@@ -17,8 +17,6 @@
 #error "stacktrace_win.cpp used but not on a windows system"
 #endif
 
-#define g2_thread_local __declspec(thread) 
-
 #include <string>
 #include <windows.h>
 #include "crashhandler.hpp"


### PR DESCRIPTION
In case the hook given by '''setFatalPreLoggingHook(...)''' introduces a fatal crash (such as windows with __debugbreak() in console or in release mode) then the recursive crash will be stopped. 