### PR TITLE
fixing cross compilation on Linux for MINGW gcc 4.8.2

### DIFF
--- a/Build.cmake
+++ b/Build.cmake
@@ -24,14 +24,16 @@ ELSEIF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
    MESSAGE("cmake for GCC ")
    IF (APPLE)
        set(CMAKE_CXX_FLAGS "-Wall -Wunused -std=c++11  -pthread -D_GLIBCXX_USE_NANOSLEEP")
+   ELSEIF (MINGW)
+       set(CMAKE_CXX_FLAGS "-Wall -Wunused -std=c++11  -pthread -D_GLIBCXX_USE_NANOSLEEP -D_GLIBCXX_USE_SCHED_YIELD")
    ELSE()
        set(PLATFORM_LINK_LIBRIES rt)
        set(CMAKE_CXX_FLAGS "-Wall -rdynamic -Wunused -std=c++11 -pthread -D_GLIBCXX_USE_NANOSLEEP -D_GLIBCXX_USE_SCHED_YIELD")
    ENDIF()
+ENDIF()
 
 
-
-ELSEIF (MSVC OR MINGW) 
+IF (MSVC OR MINGW)
   set(PLATFORM_LINK_LIBRIES dbghelp)
       # VC11 bug: http://code.google.com/p/googletest/issues/detail?id=408
       #          add_definition(-D_VARIADIC_MAX=10)

--- a/src/stacktrace_windows.cpp
+++ b/src/stacktrace_windows.cpp
@@ -15,7 +15,7 @@
 #include "stacktrace_windows.hpp"
 #include "g2log.hpp"
 #include <windows.h>
-#include <DbgHelp.h>
+#include <dbghelp.h>
 #include <map>
 #include <memory>
 #include <atomic>


### PR DESCRIPTION
Hello,
Here are my modifications to fix cross compilation on Linux with mingw-w64.
I checked compilation and unittests on the following plateforms:
* Linux Mint 17 with g++ 4.8.2
* Linux Mint 17 with mingw-w64 4.8.2 (cross compilation)
* Windows 7 with MSVC 2013
* Windows 7 with mingw-w64 4.9.3

Thanks for this library