### PR TITLE
small fixes to squash some compile warnings

### DIFF
--- a/Build.cmake
+++ b/Build.cmake
@@ -28,7 +28,7 @@ IF ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
    ELSE()
        set(PLATFORM_LINK_LIBRIES rt  c++abi)
    ENDIF()
-  SET(CMAKE_CXX_FLAGS  "-Wall -std=c++11  -pthread -stdlib=libc++ -Wunused -D_GLIBCXX_USE_NANOSLEEP")
+  SET(CMAKE_CXX_FLAGS  "-Wall -std=c++11 -stdlib=libc++ -Wunused -D_GLIBCXX_USE_NANOSLEEP")
 
 
 
@@ -85,6 +85,9 @@ ENDIF()
 
    add_library(g3logger_shared SHARED ${SRC_FILES})
    set_target_properties(g3logger_shared PROPERTIES LINKER_LANGUAGE CXX)
+   IF(APPLE)
+     set_target_properties(g3logger_shared PROPERTIES MACOSX_RPATH TRUE)
+   ENDIF(APPLE)
    target_link_libraries(g3logger_shared ${PLATFORM_LINK_LIBRIES})
   
    SET(G3LOG_SHARED_LIBRARY g3logger_shared)


### PR DESCRIPTION
- set target_property for rpath handling on OSX
- remove unused "-pthread" flags for clang compilation