### PR TITLE
Custom signal handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # 2010 by KjellKod.cc. This is PUBLIC DOMAIN to use at your own risk and comes
 # with no warranties. This code is yours to share, use and modify with no
 # strings attached and no restrictions or obligations.
-# 
+#   
 # For more information see g3log/LICENSE or refer refer to http://unlicense.org
 # ============================================================================*/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # For more information see g3log/LICENSE or refer refer to http://unlicense.org
 # ============================================================================*/
 
-
+    
 # Below are details for compiling on Windows and Linux
 # by default only an example g3log binary is created
 # the performance and unit tests creation can be enabled by switching their

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # 2010 by KjellKod.cc. This is PUBLIC DOMAIN to use at your own risk and comes
 # with no warranties. This code is yours to share, use and modify with no
 # strings attached and no restrictions or obligations.
-#           
+#                    
 # For more information see g3log/LICENSE or refer refer to http://unlicense.org
 # ============================================================================*/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # 2010 by KjellKod.cc. This is PUBLIC DOMAIN to use at your own risk and comes
 # with no warranties. This code is yours to share, use and modify with no
 # strings attached and no restrictions or obligations.
-#   
+#           
 # For more information see g3log/LICENSE or refer refer to http://unlicense.org
 # ============================================================================*/
 

--- a/example/main_fatal_choice.cpp
+++ b/example/main_fatal_choice.cpp
@@ -147,7 +147,8 @@ namespace
 
 
    void SegFaultAttempt_x10000() NOEXCEPT {
-      deathfunc f = []{Throw(); *(char*)0 = 0; char* ptr = 0; *ptr = 1; AccessViolation();};
+      
+      deathfunc f = []{char* ptr = 0; *ptr = 1; };
       Death_x10000(f, "throw uncaught exception... and then some sigsegv calls");
    }
 
@@ -293,6 +294,21 @@ int main(int argc, char **argv)
    g3::initializeLogging(worker.get());
    g3::setFatalPreLoggingHook(&breakHere);
 
+
+   // <sigh>: Not yet added example of fatal signals that can be overridden 
+   // Example: Running this with SIGTERM turned off, and choosing to "die by SIGTERM"
+   //          will exit the process without catching the signal
+   // 
+   // Enable the code below will override the signal setup, all signals active except SIGTERM
+   // g3::overrideSetupSignals({ {SIGABRT, "SIGABRT"}, {SIGFPE, "SIGFPE"},{SIGILL, "SIGILL"},
+   //                         {SIGSEGV, "SIGSEGV"},});
+   //
+   // the code below.... can be used to restore the signal handler again
+   // In truth: I don't really see how this can be used 
+   // ...... maybe a separate signal handler for sigterm.... and running this in a unit test?
+   //g3::restoreSignalHandlerToDefault();
+   don't compile on purpose
+   
    std::future<std::string> log_file_name = handle->call(&g3::FileSink::fileName);
 
    std::cout << "**** G3LOG FATAL EXAMPLE ***\n\n"

--- a/example/main_fatal_choice.cpp
+++ b/example/main_fatal_choice.cpp
@@ -293,22 +293,6 @@ int main(int argc, char **argv)
    auto handle= worker->addDefaultLogger(argv[0], path_to_log_file);
    g3::initializeLogging(worker.get());
    g3::setFatalPreLoggingHook(&breakHere);
-
-
-   // <sigh>: Not yet added example of fatal signals that can be overridden 
-   // Example: Running this with SIGTERM turned off, and choosing to "die by SIGTERM"
-   //          will exit the process without catching the signal
-   // 
-   // Enable the code below will override the signal setup, all signals active except SIGTERM
-   // g3::overrideSetupSignals({ {SIGABRT, "SIGABRT"}, {SIGFPE, "SIGFPE"},{SIGILL, "SIGILL"},
-   //                         {SIGSEGV, "SIGSEGV"},});
-   //
-   // the code below.... can be used to restore the signal handler again
-   // In truth: I don't really see how this can be used 
-   // ...... maybe a separate signal handler for sigterm.... and running this in a unit test?
-   //g3::restoreSignalHandlerToDefault();
-   don't compile on purpose
-   
    std::future<std::string> log_file_name = handle->call(&g3::FileSink::fileName);
 
    std::cout << "**** G3LOG FATAL EXAMPLE ***\n\n"

--- a/src/crashhandler_unix.cpp
+++ b/src/crashhandler_unix.cpp
@@ -27,6 +27,7 @@
 #include <thread>
 #include <atomic>
 #include <map>
+#include <mutex>
 
 // Linux/Clang, OSX/Clang, OSX/gcc
 #if (defined(__clang__) || defined(__APPLE__))

--- a/src/g3log/crashhandler.hpp
+++ b/src/g3log/crashhandler.hpp
@@ -9,6 +9,7 @@
  * ============================================================================*/
 #include <string>
 #include <csignal>
+#include <map>
 #include "g3log/loglevels.hpp"
 #include "g3log/generated_definitions.hpp"
 
@@ -37,6 +38,21 @@ namespace g3 {
    void installSignalHandlerForThread();
 #else
    typedef int SignalType;
+
+   /// Probably only needed for unit testing. Resets the signal handling back to default
+   /// which might be needed in case it was previously overridden
+   /// The default signals are: SIGABRT, SIGFPE, SIGILL, SIGSEGV, SIGTERM
+   void restoreSignalHandlerToDefault();
+
+   /// Overrides the existing signal handling for custom signals
+   /// For example: usage of zcmq relies on its own signal handler for SIGTERM
+   ///     so users of g3log with zcmq should then use the @ref overrideSetupSignals
+   ///     , likely with the original set of signals but with SIGTERM removed
+   /// 
+   /// call example:
+   ///  g3::overrideSetupSignals({ {SIGABRT, "SIGABRT"}, {SIGFPE, "SIGFPE"},{SIGILL, "SIGILL"},
+   //                          {SIGSEGV, "SIGSEGV"},});
+   void overrideSetupSignals(const std::map<int, std::string> overrideSignals);
 #endif
 
 


### PR DESCRIPTION
Making it possible to override the signal handling. In the case of, for example, czmq the SIGTERM is not considered fatal and is handled by czmq. 

So for users of czmq and g3log it is important to have g3log to opt out of catching SIGTERM signals. This pull request makes it possible to opt out and in of any signals. 

