### PR TITLE
Improve default formatting

### DIFF
--- a/src/logmessage.cpp
+++ b/src/logmessage.cpp
@@ -41,7 +41,7 @@ namespace g3 {
    std::string LogDetailsToString(const LogMessage& msg) {
       std::string out;
       out.append("\n" + msg.timestamp() + " " + msg.microseconds() +  "\t"
-                 + msg.level() + " [" + msg.file() + " L: " + msg.line() + "]\t");
+                 + msg.level() + " [" + msg.file() + ":" + msg.line() + "]\t");
       return out;
    }
 

--- a/test_unit/test_io.cpp
+++ b/test_unit/test_io.cpp
@@ -518,7 +518,7 @@ TEST(CustomLogLevels, AddANonFatal) {
    logger.reset();
    std::string file_content = readFileToText(logger.logFile());
    std::string expected;
-   expected += "MY_INFO_LEVEL [test_io.cpp L: " + std::to_string(line);
+   expected += "MY_INFO_LEVEL [test_io.cpp:" + std::to_string(line);
    EXPECT_TRUE(verifyContent(file_content, expected)) << file_content
          << "\n\nExpected: \n" << expected;
 }
@@ -541,7 +541,7 @@ TEST(CustomLogLevels, AddFatal) {
 
    std::string file_content = readFileToText(logger.logFile());
    std::string expected;
-   expected += "DEADLY [test_io.cpp L: " + std::to_string(line);
+   expected += "DEADLY [test_io.cpp:" + std::to_string(line);
    EXPECT_TRUE(verifyContent(file_content, expected)) << file_content
          << "\n\nExpected: \n" << expected;
    g_fatal_counter.store(0); // restore
@@ -585,7 +585,7 @@ TEST(CustomLogLevels, AddANonFatal__DidNotAddItToEnabledValue1) {
 
    std::string file_content = readFileToText(logger.logFile());
    std::string expected;
-   expected += "MY_INFO_LEVEL [test_io.cpp L: " + std::to_string(line);
+   expected += "MY_INFO_LEVEL [test_io.cpp:" + std::to_string(line);
    EXPECT_FALSE(verifyContent(file_content, expected)) << file_content
          << "\n\nExpected: \n" << expected  << "\nLevels:\n" << g3::only_change_at_initialization::printLevels();
 }
@@ -599,7 +599,7 @@ TEST(CustomLogLevels, AddANonFatal__DidNotAddItToEnabledValue2) {
 
    std::string file_content = readFileToText(logger.logFile());
    std::string expected;
-   expected += "MY_INFO_LEVEL [test_io.cpp L: " + std::to_string(line);
+   expected += "MY_INFO_LEVEL [test_io.cpp:" + std::to_string(line);
    EXPECT_FALSE(verifyContent(file_content, expected)) << file_content
          << "\n\nExpected: \n" << expected  << "\nLevels:\n" << g3::only_change_at_initialization::printLevels();
 }
@@ -612,7 +612,7 @@ TEST(CustomLogLevels, AddANonFatal__DidtAddItToEnabledValue) {
    logger.reset();
    std::string file_content = readFileToText(logger.logFile());
    std::string expected;
-   expected += "MY_INFO_LEVEL [test_io.cpp L: " + std::to_string(line);
+   expected += "MY_INFO_LEVEL [test_io.cpp:" + std::to_string(line);
    EXPECT_TRUE(verifyContent(file_content, expected)) << file_content
          << "\n\nExpected: \n" << expected;
 }


### PR DESCRIPTION
Instead of 
```
<date and time> <file>:L<line> .... 
```
have 
```
<date and time><file>:<line>...
```