### PR TITLE
suppress 'thread attribute directive ignored' warning on mingw

### DIFF
--- a/src/g3log/g3log.hpp
+++ b/src/g3log/g3log.hpp
@@ -34,9 +34,9 @@
 #define __PRETTY_FUNCTION__   __FUNCTION__
 #endif
 
-// thread_local doesn't exist on VS2013 but it might soon? (who knows)
-// to work after Microsoft has updated to be C++11 compliant
-#if !(defined(thread_local)) && (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
+// thread_local doesn't exist before VS2013
+// it exists on VS2015
+#if !(defined(thread_local)) && defined(_MSC_VER) && _MSC_VER < 1900
 #define thread_local __declspec(thread)
 #endif
 


### PR DESCRIPTION
Building with mingw-w64, I got warnings.

    src/crashhandler_windows.cpp:33:22: warning: 'thread' attribute directive ignored [-Wattributes]
        thread_local bool g_installed_thread_signal_handler = false;

In addition, Visual Studio 2015 has C++11 thread_local specifier. ref: [C++11/14/17 Features In VS 2015 RTM](http://blogs.msdn.com/b/vcblog/archive/2015/06/19/c-11-14-17-features-in-vs-2015-rtm.aspx)

So, this pullreq limits thread_local workaround to <=VS2013.