### PR TITLE
Enable an install target

### DIFF
--- a/Build.cmake
+++ b/Build.cmake
@@ -1,5 +1,5 @@
 # g3log is a KjellKod Logger
-# 2015 @author Kjell Hedström, hedstrom@kjellkod.cc 
+# 2015 @author Kjell Hedström, hedstrom@kjellkod.cc
 # ==================================================================
 # 2015 by KjellKod.cc. This is PUBLIC DOMAIN to use at your own
 #    risk and comes  with no warranties.
@@ -17,7 +17,7 @@ SET(ACTIVE_CPP0xx_DIR "Release")
 #cmake -DCMAKE_CXX_COMPILER=clang++ ..
   # WARNING: If Clang for Linux does not work with full C++11 support it might be your
   # installation that is faulty. When I tested Clang on Ubuntu I followed the following
-  # description 
+  # description
   #  1) http://kjellkod.wordpress.com/2013/09/23/experimental-g3log-with-clang/
   #  2) https://github.com/maidsafe/MaidSafe/wiki/Hacking-with-Clang-llvm-abi-and-llvm-libc
 IF ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
@@ -73,19 +73,22 @@ ENDIF()
    file(GLOB HEADER_FILES ${LOG_SRC}/g3log/*.hpp ${LOG_SRC}/*.hpp)
    #MESSAGE(" HEADER FILES ARE: ${HEADER_FILES}")
 
-   IF (MSVC OR MINGW) 
+   IF (MSVC OR MINGW)
          list(REMOVE_ITEM SRC_FILES  ${LOG_SRC}/crashhandler_unix.cpp)
    ELSE()
          list(REMOVE_ITEM SRC_FILES  ${LOG_SRC}/crashhandler_windows.cpp ${LOG_SRC}/g3log/stacktrace_windows.hpp ${LOG_SRC}/stacktrace_windows.cpp)
    ENDIF (MSVC OR MINGW)
 
    set(SRC_FILES ${SRC_FILES} ${SRC_PLATFORM_SPECIFIC})
- 
+
    # Create the g3log library
    include_directories(${LOG_SRC})
    #MESSAGE("  g3logger files: [${SRC_FILES}]")
    add_library(g3logger ${SRC_FILES})
-   set_target_properties(g3logger PROPERTIES LINKER_LANGUAGE CXX)
+   set_target_properties(g3logger PROPERTIES
+      LINKER_LANGUAGE CXX
+      OUTPUT_NAME g3logger
+      CLEAN_DIRECT_OUTPUT 1)
    target_link_libraries(g3logger ${PLATFORM_LINK_LIBRIES})
    SET(G3LOG_LIBRARY g3logger)
 
@@ -94,11 +97,14 @@ if(ADD_BUILD_WIN_SHARED OR NOT(MSVC OR MINGW))
       set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
    ENDIF()
    add_library(g3logger_shared SHARED ${SRC_FILES})
-   set_target_properties(g3logger_shared PROPERTIES LINKER_LANGUAGE CXX)
+   set_target_properties(g3logger_shared PROPERTIES
+      LINKER_LANGUAGE CXX
+      OUTPUT_NAME g3logger
+      CLEAN_DIRECT_OUTPUT 1)
    IF(APPLE)
       set_target_properties(g3logger_shared PROPERTIES MACOSX_RPATH TRUE)
    ENDIF(APPLE)
-   target_link_libraries(g3logger_shared ${PLATFORM_LINK_LIBRIES})   
+   target_link_libraries(g3logger_shared ${PLATFORM_LINK_LIBRIES})
 
    SET(G3LOG_SHARED_LIBRARY g3logger_shared)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,17 +2,17 @@
 # 2010 by KjellKod.cc. This is PUBLIC DOMAIN to use at your own risk and comes
 # with no warranties. This code is yours to share, use and modify with no
 # strings attached and no restrictions or obligations.
-#                    
+#
 # For more information see g3log/LICENSE or refer refer to http://unlicense.org
 # ============================================================================*/
 
-    
+
 # Below are details for compiling on Windows and Linux
 # by default only an example g3log binary is created
 # the performance and unit tests creation can be enabled by switching their
 # OPTIONs from OFF to ON --- See below at around line 110
 
-# === WINDOWS === 
+# === WINDOWS ===
 # Example for: Visual Studio 2013 (earlier should work too)
 # 1. please use the "Visual Studio Command Prompt 12 (2013)"
 # 2. from the g3log folder
@@ -32,8 +32,8 @@
 #    mkdir build
 #    cd build
 # >> create makefiles in g3log/build directory
-#   cmake -DCMAKE_BUILD_TYPE=Release .. 
-#    make -jN   (where N stands for number of cores you want to utilize)     
+#   cmake -DCMAKE_BUILD_TYPE=Release ..
+#    make -jN   (where N stands for number of cores you want to utilize)
 #
 #
 #
@@ -41,9 +41,9 @@
 #   From g3log
 #   mkdir build && cd build
 #   cmake -DCMAKE_CXX_COMPILER=clang++ ..
-#   if you want to double-check settings:   "VERBOSE=1 make" 
-#   otherwise just run:   "make -j"                        
-#                
+#   if you want to double-check settings:   "VERBOSE=1 make"
+#   otherwise just run:   "make -j"
+#
 # ============================================================================
 
 cmake_minimum_required (VERSION 2.8)
@@ -72,7 +72,7 @@ endif()
 
    # =========================================================================
    # G3 Macro definitions in Options.cmake are written to file
-   #    this avoids having to re-state your definitions in your source code 
+   #    this avoids having to re-state your definitions in your source code
    #    or compile options
    #==========================================================================
    INCLUDE (${g3log_SOURCE_DIR}/GenerateMacroDefinitionsFile.cmake)
@@ -84,12 +84,12 @@ endif()
    #==========================================================================
    INCLUDE (${g3log_SOURCE_DIR}/Build.cmake)
 
-   
+
 
    # ============================================================================
    # EXAMPLE OPTIONS: By defauls is ON. This will create 'g3log-FATAL-* examples'
    # ============================================================================
-   # DISABLE WITH:  -DADD_FATAL_EXAMPLE=OFF    
+   # DISABLE WITH:  -DADD_FATAL_EXAMPLE=OFF
    INCLUDE (${g3log_SOURCE_DIR}/example/Example.cmake)
 
 
@@ -97,15 +97,15 @@ endif()
    # ============================================================================
    # PERFORMANCE TEST OPTIONS: Performance operations for g3log
    # ============================================================================
-   # ENABLE WITH:  -DADD_G3LOG_PERFORMANCE=ON  
+   # ENABLE WITH:  -DADD_G3LOG_PERFORMANCE=ON
    INCLUDE (${g3log_SOURCE_DIR}/test_performance/Performance.cmake)
 
-      
+
 
    # ==========================================================================
-   # UNIT TEST OPTIONS: 
+   # UNIT TEST OPTIONS:
    # ============================================================================
-   # ENABLE WITH:  -DADD_G3LOG_UNIT_TEST=ON  
+   # ENABLE WITH:  -DADD_G3LOG_UNIT_TEST=ON
    INCLUDE (${g3log_SOURCE_DIR}/test_unit/Test.cmake)
 
 
@@ -114,21 +114,21 @@ endif()
 
 
 # ==========================================================================
-# BETA : package manager for G3Log,. not yet reliable. Use at your own risk 
+# BETA : package manager for G3Log,. not yet reliable. Use at your own risk
 # ==========================================================================
-#   Package handling is done AFTER all other CMake setup   
+#   Package handling is done AFTER all other CMake setup
 #
-#   usage:   make package   
-#         
+#   usage:   make package
+#
 #   Check the output result and install accordingly.
 # ==========================================================================
-# INCLUDE (${g3log_SOURCE_DIR}/CPackLists.txt)
+INCLUDE (${g3log_SOURCE_DIR}/CPackLists.txt)
 
 IF (NOT MSVC)
    MESSAGE("\n\n
       *******************************************************************
-      Please do 'make clean-cmake' before next cmake generation. 
-         It is a good idea to purge your build directory of CMake 
+      Please do 'make clean-cmake' before next cmake generation.
+         It is a good idea to purge your build directory of CMake
          generated cache files
       *******************************************************************
        ")

--- a/CPackLists.txt
+++ b/CPackLists.txt
@@ -2,7 +2,7 @@
 # 2015 by KjellKod.cc. This is PUBLIC DOMAIN to use at your own risk and comes
 # with no warranties. This code is yours to share, use and modify with no
 # strings attached and no restrictions or obligations.
-# 
+#
 # For more information see g3log/LICENSE or refer refer to http://unlicense.org
 # ============================================================================*/
 
@@ -18,16 +18,18 @@
  #           COMPONENT headers)
 
 
+   SET(CMAKE_INSTALL_LIBDIR lib CACHE PATH "Output dir for libraries")
+   SET(CMAKE_INSTALL_HEADERDIR include CACHE PATH "Output dir for headers")
 
-   INSTALL( TARGETS g3logger_shared
-            ARCHIVE
-            LIBRARY DESTINATION /usr/local/lib
+   INSTALL( TARGETS g3logger g3logger_shared
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT libraries)
 
    INSTALL( FILES ${HEADER_FILES}
-            DESTINATION /usr/local/include/g3log
+            DESTINATION ${CMAKE_INSTALL_HEADERDIR}/g3log
             COMPONENT headers)
-                      
+
 
   SET(CPACK_COMPONENTS_ALL libraries headers)
   SET(CPACK_COMPONENT_LIBRARIES_DISPLAY_NAME "G3Log libraries")
@@ -55,5 +57,5 @@ INCLUDE(CPack)
 
 
 #  2094  sudo dpkg -r g3log
-# 2100  sudo dpkg -i g3log-1.1.0-Linux.deb 
+# 2100  sudo dpkg -i g3log-1.1.0-Linux.deb
 # 2101  sudo dpkg -L g3log


### PR DESCRIPTION
Should work fine on Unix systems, and support install prefixes.
Installs both a static and a shared library to the same location, so we get an .a and a .so/.dylib file, which can be linked to in the ordinary way, ie. `-lg3logger`.

As discussed in #49 

More work could be done, but for now I think we need some basic support added. 