### PR TITLE
use 'toString' to get the formatted output in the fatal cerr message …

### DIFF
--- a/src/logworker.cpp
+++ b/src/logworker.cpp
@@ -54,7 +54,7 @@ namespace g3 {
       uniqueMsg->write().append("). ").append(exiting).append(" ").append(reason)
       .append("\nLog content flushed flushed sucessfully to sink\n\n");
 
-      std::cerr << uniqueMsg->message() << std::flush;
+      std::cerr << uniqueMsg->toString() << std::flush;
       for (auto& sink : _sinks) {
          LogMessage msg(*(uniqueMsg));
          sink->send(LogMessageMover(std::move(msg)));


### PR DESCRIPTION
use 'toString' to get the formatted output in the fatal cerr messagewhen a LOG fatal or CONTRACT happens. This was already OK on the sink side