### PR TITLE
Avoid initialization/shutdown deadlock

### DIFF
--- a/src/g3log.cpp
+++ b/src/g3log.cpp
@@ -31,7 +31,8 @@
 #include <iostream>
 #include <thread>
 #include <atomic>
-
+#include <cstdlib>
+#include <sstream>
 
 namespace {
    std::once_flag g_initialize_flag;
@@ -63,8 +64,15 @@ namespace g3 {
          installCrashHandler();
       });
       std::lock_guard<std::mutex> lock(g_logging_init_mutex);
-      CHECK(!internal::isLoggingInitialized());
-      CHECK(bgworker != nullptr);
+      if (internal::isLoggingInitialized() || nullptr == bgworker) {
+         std::ostringstream exitMsg;
+         exitMsg << __FILE__ "->" << __FUNCTION__ << ":" << __LINE__ << std::endl;
+         exitMsg << "\tFatal exit due to illegal initialization of g3::LogWorker\n";
+         exitMsg << "\t(due to multiple initializations? : " << std::boolalpha << internal::isLoggingInitialized();
+         exitMsg << ", due to nullptr == bgworker? : " << std::boolalpha << (nullptr == bgworker) << ")";
+         std::cerr << exitMsg.str() << std::endl;
+         std::exit(EXIT_FAILURE);
+      }
 
       // Save the first uninitialized message, if any
       std::call_once(g_save_first_unintialized_flag, [&bgworker] {


### PR DESCRIPTION
 Avoid initialization/shutdown deadlockthat could occur due to wrong use of the API. 

This was raised as an issue by @rakeshsehgal1