### PR TITLE
Typo fix (Vaulue → Value)

### DIFF
--- a/src/g3log/loglevels.hpp
+++ b/src/g3log/loglevels.hpp
@@ -62,7 +62,7 @@ struct LEVELS {
 
 
 namespace g3 {
-   static const int kDebugVaulue = 0;
+   static const int kDebugValue = 0;
    static const int kInfoValue = 100;
    static const int kWarningValue = 500;
    static const int kFatalValue = 1000;
@@ -70,9 +70,9 @@ namespace g3 {
 }
 
 #if (defined(CHANGE_G3LOG_DEBUG_TO_DBUG))
-const LEVELS DBUG {g3::kDebugVaulue, {"DEBUG"}},
+const LEVELS DBUG {g3::kDebugValue, {"DEBUG"}},
 #else
-const LEVELS DEBUG {g3::kDebugVaulue, {"DEBUG"}},
+const LEVELS DEBUG {g3::kDebugValue, {"DEBUG"}},
 #endif
       INFO {g3::kInfoValue, {"INFO"}},
       WARNING {g3::kWarningValue, {"WARNING"}},

--- a/src/loglevels.cpp
+++ b/src/loglevels.cpp
@@ -40,7 +40,7 @@ namespace g3 {
       }
 
 #ifdef G3_DYNAMIC_LOGGING
-      std::map<int, atomicbool> g_log_level_status = {{g3::kDebugVaulue, true}, {INFO.value, true}, {WARNING.value, true}, {FATAL.value, true}};
+      std::map<int, atomicbool> g_log_level_status = {{g3::kDebugValue, true}, {INFO.value, true}, {WARNING.value, true}, {FATAL.value, true}};
 #endif
    } // internal
 
@@ -61,7 +61,7 @@ namespace g3 {
 
       void reset() {
          internal::g_log_level_status.clear();
-         internal::g_log_level_status = std::map<int, atomicbool>{{g3::kDebugVaulue, true}, {INFO.value, true}, {WARNING.value, true}, {FATAL.value, true}};
+         internal::g_log_level_status = std::map<int, atomicbool>{{g3::kDebugValue, true}, {INFO.value, true}, {WARNING.value, true}, {FATAL.value, true}};
       }
    } // only_change_at_initialization
 #endif


### PR DESCRIPTION
The constant `g3::kDebugVaulue`'s name is misspelled.