### PR TITLE
Updated cmake version to correct string compare behaviour.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@
 #
 # ============================================================================
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.1)
 ENABLE_LANGUAGE(CXX)
 set(CMAKE_BUILD_TYPE Release)
 


### PR DESCRIPTION
When building g3log with newer CMake versions (>3.1) there will be several warnings about a change in string comparison behavior/policy (see #125 for more info). The old policy can lead to some unexpected comparison results.

To be able to use the new policy I had to require a newer CMake version (at least I think that is the most elegant way). I am not sure if there was any reason for using an older version but if not it might be a good idea to update.
