### PR TITLE
Fix compilation errors when CHANGE_G3LOG_DEBUG_TO_DBUG is enabled-

### DIFF
--- a/example/main_contract.cpp
+++ b/example/main_contract.cpp
@@ -30,6 +30,11 @@ namespace example_fatal
    }
 } // example fatal
 
+#ifdef CHANGE_G3LOG_DEBUG_TO_DBUG
+#undef DEBUG
+#define DEBUG DBUG
+#endif
+
 int main(int argc, char **argv)
 {
    double pi_d = 3.1415926535897932384626433832795;

--- a/example/main_fatal_choice.cpp
+++ b/example/main_fatal_choice.cpp
@@ -24,6 +24,11 @@
 #define NOEXCEPT throw()
 #endif
 
+#ifdef CHANGE_G3LOG_DEBUG_TO_DBUG
+#undef DEBUG
+#define DEBUG DBUG
+#endif
+
 namespace
 {
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))

--- a/example/main_sigsegv.cpp
+++ b/example/main_sigsegv.cpp
@@ -22,6 +22,11 @@ namespace
 #endif
 }
 
+#ifdef CHANGE_G3LOG_DEBUG_TO_DBUG
+#undef DEBUG
+#define DEBUG DBUG
+#endif
+
 namespace example_fatal
 {
    // on Ubunti this caused get a compiler warning with gcc4.6

--- a/test_unit/testing_helpers.h
+++ b/test_unit/testing_helpers.h
@@ -135,6 +135,9 @@ private:
   };
 } // testing_helpers
 
-
+#ifdef CHANGE_G3LOG_DEBUG_TO_DBUG
+#undef DEBUG
+#define DEBUG DBUG
+#endif
 
 


### PR DESCRIPTION
Fixing the following issue:
When using DBUG instead of DEBUG level through cmake unit tests and main programs would no longer compile.