### PR TITLE
force /utf-8 for MSVC compiler

### DIFF
--- a/Build.cmake
+++ b/Build.cmake
@@ -58,6 +58,7 @@ ENDIF()
 
 
 IF (MSVC OR MINGW)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /utf-8") # source code already in utf-8, force it for compilers in non-utf8_windows_locale
   set(PLATFORM_LINK_LIBRIES dbghelp)
       # VC11 bug: http://code.google.com/p/googletest/issues/detail?id=408
       #          add_definition(-D_VARIADIC_MAX=10)


### PR DESCRIPTION
The source code is already in utf-8; 
but in non-English windows (like mine CP936), it will report warning C4819.
`warning C4819: The file contains a character that cannot be represented in the current code page`

Now in Build.cmake, force utf-8 for MSVC compilers in non-utf8_windows_locale.