### PR TITLE
Fix typos in readme.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,7 +56,7 @@ The logger will catch certain fatal events *(Linux/OSX: signals, Windows: fatal 
  
 6. It is cross platform. Tested and used by me or by clients on OSX, Windows, Ubuntu, CentOS
 
-7. G3log and G2log is used world wide in commercial products as well as hobby projects. G2log is used since early 2011.
+7. G3log and G2log are used worldwide in commercial products as well as hobby projects. G2log is used since early 2011.
 
 8. The code is given for free as public domain. This gives the option to change, use, and do whatever with it, no strings attached.
 


### PR DESCRIPTION
"G3log and G2log is used world wide in commercial products as well as hobby projects."
-> "G3log and G2log are used worldwide in commercial products as well as hobby projects."
Fix #165 