### PR TITLE
Time adjustments for VMs and 32-bit embedded 

### DIFF
--- a/src/filesink.cpp
+++ b/src/filesink.cpp
@@ -9,6 +9,7 @@
 #include "g3log/filesink.hpp"
 #include "filesinkhelper.ipp"
 #include <cassert>
+#include <chrono>
 
 namespace g3 {
    using namespace internal;
@@ -41,7 +42,8 @@ namespace g3 {
 
    FileSink::~FileSink() {
       std::string exit_msg {"g3log g3FileSink shutdown at: "};
-      exit_msg.append(localtime_formatted(systemtime_now(), internal::time_formatted)).append("\n");
+      auto now = std::chrono::system_clock::now();
+      exit_msg.append(localtime_formatted(now, internal::time_formatted)).append("\n");
       filestream() << exit_msg << std::flush;
 
       exit_msg.append("Log file at: [").append(_log_file_with_path).append("]\n");
@@ -56,7 +58,7 @@ namespace g3 {
 
    std::string FileSink::changeLogFile(const std::string &directory, const std::string &logger_id) {
 
-      auto now = g3::systemtime_now();
+      auto now = std::chrono::system_clock::now();
       auto now_formatted = g3::localtime_formatted(now, {internal::date_formatted + " " + internal::time_formatted});
 
       std::string file_name = createLogFileName(_log_prefix_backup, logger_id);

--- a/src/filesinkhelper.ipp
+++ b/src/filesinkhelper.ipp
@@ -79,7 +79,8 @@ namespace g3 {
       std::string header() {
          std::ostringstream ss_entry;
          //  Day Month Date Time Year: is written as "%a %b %d %H:%M:%S %Y" and formatted output as : Wed Sep 19 08:28:16 2012
-         ss_entry << "\t\tg3log created log at: " << g3::localtime_formatted(g3::systemtime_now(), "%a %b %d %H:%M:%S %Y") << "\n";
+         auto now = std::chrono::system_clock::now();
+         ss_entry << "\t\tg3log created log at: " << g3::localtime_formatted(now, "%a %b %d %H:%M:%S %Y") << "\n";
          ss_entry << "\t\tLOG format: [YYYY/MM/DD hh:mm:ss uuu* LEVEL FILE->FUNCTION:LINE] message";
          ss_entry << "\t\t(uuu*: microseconds fractions of the seconds value)\n\n";
          return ss_entry.str();
@@ -88,8 +89,11 @@ namespace g3 {
       std::string createLogFileName(const std::string &verified_prefix, const std::string &logger_id) {
          std::stringstream oss_name;
          oss_name << verified_prefix << ".";
-         if( logger_id != "" ) oss_name << logger_id << ".";
-         oss_name << g3::localtime_formatted(g3::systemtime_now(), file_name_time_formatted);
+         if( logger_id != "" ) {
+            oss_name << logger_id << ".";
+         }
+         auto now = std::chrono::system_clock::now();
+         oss_name << g3::localtime_formatted(now, file_name_time_formatted);
          oss_name << ".log";
          return oss_name.str();
       }

--- a/src/g3log.cpp
+++ b/src/g3log.cpp
@@ -36,7 +36,7 @@
 
 namespace {
    std::once_flag g_initialize_flag;
-   g3::LogWorker *g_logger_instance = nullptr; // instantiated and OWNED somewhere else (main)
+   g3::LogWorker* g_logger_instance = nullptr; // instantiated and OWNED somewhere else (main)
    std::mutex g_logging_init_mutex;
 
    std::unique_ptr<g3::LogMessage> g_first_unintialized_msg = {nullptr};
@@ -59,7 +59,7 @@ namespace g3 {
    // several times...
    //                    for all other practical use, it shouldn't!
 
-   void initializeLogging(LogWorker *bgworker) {
+   void initializeLogging(LogWorker* bgworker) {
       std::call_once(g_initialize_flag, [] {
          installCrashHandler();
       });
@@ -139,7 +139,7 @@ namespace g3 {
        *         and the logging continues to be active.
        * @return true if the correct worker was given,. and shutDownLogging was called
        */
-      bool shutDownLoggingForActiveOnly(LogWorker *active) {
+      bool shutDownLoggingForActiveOnly(LogWorker* active) {
          if (isLoggingInitialized() && nullptr != active && (active != g_logger_instance)) {
             LOG(WARNING) << "\n\t\tAttempted to shut down logging, but the ID of the Logger is not the one that is active."
                          << "\n\t\tHaving multiple instances of the g3::LogWorker is likely a BUG"
@@ -156,8 +156,8 @@ namespace g3 {
 
       /** explicits copy of all input. This is makes it possibly to use g3log across dynamically loaded libraries
       * i.e. (dlopen + dlsym)  */
-      void saveMessage(const char *entry, const char *file, int line, const char *function, const LEVELS &level,
-                       const char *boolean_expression, int fatal_signal, const char *stack_trace) {
+      void saveMessage(const char* entry, const char* file, int line, const char* function, const LEVELS& level,
+                       const char* boolean_expression, int fatal_signal, const char* stack_trace) {
          LEVELS msgLevel {level};
          LogMessagePtr message {std2::make_unique<LogMessage>(file, line, function, msgLevel)};
          message.get()->write().append(entry);
@@ -209,7 +209,7 @@ namespace g3 {
                g_first_unintialized_msg = incoming.release();
                std::string err = {"LOGGER NOT INITIALIZED:\n\t\t"};
                err.append(g_first_unintialized_msg->message());
-               std::string &str = g_first_unintialized_msg->write();
+               std::string& str = g_first_unintialized_msg->write();
                str.clear();
                str.append(err); // replace content
                std::cerr << str << std::endl;

--- a/src/g3log/logmessage.hpp
+++ b/src/g3log/logmessage.hpp
@@ -87,7 +87,7 @@ namespace g3 {
       // Complete access to the raw data in case the helper functions above
       // are not enough.
       //
-      timespec _timestamp;
+      g3::system_time_point _timestamp;
       std::thread::id _call_thread_id;
       std::string _file;
       std::string _file_path;

--- a/src/g3log/time.hpp
+++ b/src/g3log/time.hpp
@@ -42,12 +42,12 @@ namespace g3 {
 
    //  custom wrap for std::chrono::system_clock::now()but this one 
    // returns timespec struct instead which is what we use in g3log
-   struct timespec systemtime_now();
+   //struct timespec systemtime_now();
 
    // OSX, Windows needed wrapper for std::timespec_get(struct timespec *ts, int base)
    //   OSX and Windows also lacks the POSIX clock_gettime(int base, struct timespec *ts)
    //   so for that reason we go with the std::timespec_get(...) but wrap it
-   int timespec_get(struct timespec* ts/*, int base*/);
+   //int timespec_get(struct timespec* ts/*, int base*/);
 
    // This mimics the original "std::put_time(const std::tm* tmb, const charT* fmt)"
    // This is needed since latest version (at time of writing) of gcc4.7 does not implement this library function yet.
@@ -63,7 +63,7 @@ namespace g3 {
    * WARNING: At time of writing there is only so-so compiler support for
    * std::put_time. A possible fix if your c++11 library is not updated is to
    * modify this to use std::strftime instead */
-   std::string localtime_formatted(const timespec& time_snapshot, const std::string& time_format) ;
+   std::string localtime_formatted(const system_time_point& ts, const std::string& time_format) ;
 }
 
 

--- a/src/g3log/time.hpp
+++ b/src/g3log/time.hpp
@@ -22,10 +22,14 @@
 //          std::string put_time(const struct tm* tmb, const char* c_time_format)
 
 namespace g3 {
+   typedef std::chrono::time_point<std::chrono::system_clock>  system_time_point;
+   typedef std::chrono::milliseconds milliseconds;
+   typedef std::chrono::microseconds microseconds;
+
    namespace internal {
       enum class Fractional {Millisecond, Microsecond, Nanosecond, NanosecondDefault};
       Fractional getFractional(const std::string& format_buffer, size_t pos);
-      std::string to_string(const timespec& time_snapshot, Fractional fractional);
+      std::string localtime_formatted_fractions(const g3::system_time_point& ts, std::string format_buffer);
       static const std::string date_formatted = "%Y/%m/%d";
       // %f: fractions of seconds (%f is nanoseconds)
       // %f3: milliseconds, 3 digits: 001
@@ -34,9 +38,6 @@ namespace g3 {
       static const std::string time_formatted = "%H:%M:%S %f6";
    } // internal
 
-   typedef std::chrono::time_point<std::chrono::system_clock>  system_time_point;
-   typedef std::chrono::milliseconds milliseconds;
-   typedef std::chrono::microseconds microseconds;
 
       
 

--- a/src/g3log/time.hpp
+++ b/src/g3log/time.hpp
@@ -29,6 +29,7 @@ namespace g3 {
    namespace internal {
       enum class Fractional {Millisecond, Microsecond, Nanosecond, NanosecondDefault};
       Fractional getFractional(const std::string& format_buffer, size_t pos);
+      std::string to_string(const g3::system_time_point& ts, Fractional fractional);
       std::string localtime_formatted_fractions(const g3::system_time_point& ts, std::string format_buffer);
       static const std::string date_formatted = "%Y/%m/%d";
       // %f: fractions of seconds (%f is nanoseconds)
@@ -38,17 +39,6 @@ namespace g3 {
       static const std::string time_formatted = "%H:%M:%S %f6";
    } // internal
 
-
-      
-
-   //  custom wrap for std::chrono::system_clock::now()but this one 
-   // returns timespec struct instead which is what we use in g3log
-   //struct timespec systemtime_now();
-
-   // OSX, Windows needed wrapper for std::timespec_get(struct timespec *ts, int base)
-   //   OSX and Windows also lacks the POSIX clock_gettime(int base, struct timespec *ts)
-   //   so for that reason we go with the std::timespec_get(...) but wrap it
-   //int timespec_get(struct timespec* ts/*, int base*/);
 
    // This mimics the original "std::put_time(const std::tm* tmb, const charT* fmt)"
    // This is needed since latest version (at time of writing) of gcc4.7 does not implement this library function yet.

--- a/src/logmessage.cpp
+++ b/src/logmessage.cpp
@@ -131,8 +131,7 @@ namespace g3 {
       , _file_path(file)
       , _line(line)
       , _function(function)
-      , _level(level)
-   {
+      , _level(level) {
    }
 
 
@@ -153,7 +152,7 @@ namespace g3 {
       , _message(other._message) {
    }
 
-   LogMessage::LogMessage(LogMessage &&other)
+   LogMessage::LogMessage(LogMessage&& other)
       : _timestamp(other._timestamp)
       , _call_thread_id(other._call_thread_id)
       , _file(std::move(other._file))

--- a/src/logmessage.cpp
+++ b/src/logmessage.cpp
@@ -125,14 +125,15 @@ namespace g3 {
 
    LogMessage::LogMessage(const std::string& file, const int line,
                           const std::string& function, const LEVELS& level)
-      : _call_thread_id(std::this_thread::get_id())
+      : _timestamp(std::chrono::system_clock::now())
+      , _call_thread_id(std::this_thread::get_id())
       , _file(splitFileName(file))
       , _file_path(file)
       , _line(line)
       , _function(function)
       , _level(level)
    {
-      g3::timespec_get(&_timestamp/*, TIME_UTC*/);
+      //g3::timespec_get(&_timestamp/*, TIME_UTC*/);
       // Another possibility could be to Falling back to clock_gettime as TIME_UTC 
       // is not recognized by travis CI. 
       // i.e. clock_gettime(CLOCK_REALTIME, &_timestamp);

--- a/src/logmessage.cpp
+++ b/src/logmessage.cpp
@@ -133,10 +133,6 @@ namespace g3 {
       , _function(function)
       , _level(level)
    {
-      //g3::timespec_get(&_timestamp/*, TIME_UTC*/);
-      // Another possibility could be to Falling back to clock_gettime as TIME_UTC 
-      // is not recognized by travis CI. 
-      // i.e. clock_gettime(CLOCK_REALTIME, &_timestamp);
    }
 
 

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -78,18 +78,18 @@ namespace g3 {
 
 
 namespace g3 {
-   struct timespec systemtime_now() {
-      struct timespec ts;
-      timespec_get(&ts);
-      return ts;
-   }
+//   struct timespec systemtime_now() {
+//      struct timespec ts = {};
+//      timespec_get(&ts);
+//      return ts;
+//   }
 
 
    // std::timespec_get or posix clock_gettime)(...) are not
    // implemented on OSX and ubuntu gcc5 has no support for std::timespec_get(...) as of yet
    // so instead we roll our own.
-   int timespec_get(struct timespec* ts/*, int base*/) {
-      using namespace std::chrono;
+   //int timespec_get(struct timespec* ts/*, int base*/) {
+   //   using namespace std::chrono;
       
       // thanks @AndreasSchoenle for the implementation and the explanation:
       // The time since epoch for the steady_clock is not necessarily really the time since 1970.
@@ -99,27 +99,32 @@ namespace g3 {
       // 
       // Time stamps will later have system clock accuracy but relative times will have the precision
       // of the high resolution clock.   
-      thread_local const auto os_system =
-         time_point_cast<nanoseconds>(system_clock::now()).time_since_epoch();
-      thread_local const auto os_high_resolution = 
-         time_point_cast<nanoseconds>(high_resolution_clock::now()).time_since_epoch();
-      thread_local auto os = os_system - os_high_resolution;
+      //thread_local const auto os_system =
+      //   time_point_cast<nanoseconds>(system_clock::now()).time_since_epoch();
+      //thread_local const auto os_high_resolution = 
+      //   time_point_cast<nanoseconds>(high_resolution_clock::now()).time_since_epoch();
+      //thread_local auto os = os_system - os_high_resolution;
 
       // 32-bit system work-around, where apparenetly the os correction above could sometimes 
       // become negative. This correction will only be done once per thread
-      if (os.count() < 0 ) {
-         os =  os_system;
-      }
+      //if (os.count() < 0 ) {
+      //   os =  os_system;
+      //}
 
-      auto now_ns = (time_point_cast<nanoseconds>(high_resolution_clock::now()).time_since_epoch() + os).count();
-      const auto kNanos = 1000000000;
-      ts ->tv_sec = now_ns / kNanos;
-      ts ->tv_nsec = now_ns % kNanos;
-      #ifdef TIME_UTC
-         return TIME_UTC;
-      #endif
-      return 1;
-   }
+      //auto now_ns = (time_point_cast<nanoseconds>(high_resolution_clock::now()).time_since_epoch() + os).count();
+      //const auto kNanos = 1000000000;
+      //ts ->tv_sec = now_ns / kNanos;
+      //ts ->tv_nsec = now_ns % kNanos;
+
+      //const auto kNanos = 1000000000;
+     // auto now = system_clock::now();
+     // ts ->tv_sec = time_point_cast<seconds>(now).time_since_epoch().count();
+     // ts ->tv_nsec = time_point_cast<nanoseconds>(now).time_since_epoch().count();
+     // #ifdef TIME_UTC
+     //    return TIME_UTC;
+     // #endif
+     // return 1;
+   //}
 
 
 
@@ -138,7 +143,7 @@ namespace g3 {
       char buffer[size]; // IMPORTANT: check now and then for when gcc will implement std::put_time.
       //                    ... also ... This is way more buffer space then we need
 
-      auto success = std::strftime(buffer, size, c_time_format, tmb);
+     auto success = std::strftime(buffer, size, c_time_format, tmb);
       // In DEBUG the assert will trigger a process exit. Once inside the if-statement
       // the 'always true' expression will be displayed as reason for the exit
       //
@@ -155,12 +160,12 @@ namespace g3 {
 
 
 
-   tm localtime(const std::time_t& time) {
+   tm localtime(const std::time_t& ts) {
       struct tm tm_snapshot;
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__) && !defined(__GNUC__))
-      localtime_s(&tm_snapshot, &time); // windsows
+      localtime_s(&tm_snapshot, &ts); // windsows
 #else
-      localtime_r(&time, &tm_snapshot); // POSIX
+      localtime_r(&ts, &tm_snapshot); // POSIX
 #endif
       return tm_snapshot;
    }
@@ -168,24 +173,27 @@ namespace g3 {
 
 
 
-   std::string localtime_formatted(const timespec& time_snapshot, const std::string& time_format) {
-      auto format_buffer = time_format;  // copying format string to a separate buffer
+   std::string localtime_formatted(const system_time_point& ts, const std::string& time_format) {
+   auto format_buffer = time_format;  // copying format string to a separate buffer
 
       // iterating through every "%f" instance in the format string
-      auto identifierExtraSize = 0;
-      for (size_t pos = 0; (pos = format_buffer.find(g3::internal::kFractionalIdentier, pos)) != std::string::npos; pos += g3::internal::kFractionalIdentierSize + identifierExtraSize) {
+//      auto identifierExtraSize = 0;
+//      for (size_t pos = 0; (pos = format_buffer.find(g3::internal::kFractionalIdentier, pos)) != std::string::npos; pos += g3::internal::kFractionalIdentierSize + identifierExtraSize) {
          // figuring out whether this is nano, micro or milli identifier
-         auto type = g3::internal::getFractional(format_buffer, pos);
-         auto value = g3::internal::to_string(time_snapshot, type);
-         auto padding = 0;
-         if (type != g3::internal::Fractional::NanosecondDefault) {
-            padding = 1;
-         }
+//         auto type = g3::internal::getFractional(format_buffer, pos);
+//         auto value = g3::internal::to_string(time_snapshot, type);
+//         auto padding = 0;
+//         if (type != g3::internal::Fractional::NanosecondDefault) {
+//            padding = 1;
+ //        }
 
          // replacing "%f[3|6|9]" with sec fractional part value
-         format_buffer.replace(pos, g3::internal::kFractionalIdentier.size() + padding, value);
-      }
-      std::tm t = localtime(time_snapshot.tv_sec);   
+ //        format_buffer.replace(pos, g3::internal::kFractionalIdentier.size() + padding, value);
+  //    }
+
+      auto time_point = std::chrono::system_clock::to_time_t(ts);
+
+       std::tm t = localtime(time_point);   
       return g3::put_time(&t, format_buffer.c_str()); // format example: //"%Y/%m/%d %H:%M:%S");
    }
 } // g3

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -39,38 +39,91 @@ namespace g3 {
       }
 
 
-      // Returns the fractional as a string with padded zeroes
-      // 1 ms --> 001
-      // 1 us --> 000001
-      // 1 ns --> 000000001
-      std::string to_string(const timespec& time_snapshot, Fractional fractional) {
-         auto ns = time_snapshot.tv_nsec;
-         auto zeroes = 9; // default ns
-         auto digitsToCut = 1; // default ns, divide by 1 makes no change
-         switch (fractional) {
-            case Fractional::Millisecond : {
-               zeroes = 3;
-               digitsToCut = 1000000;
-               break;
-            }
-            case Fractional::Microsecond : {
-               zeroes = 6;
-               digitsToCut = 1000;
-               break;
-            }
-            case Fractional::Nanosecond :
-            case Fractional::NanosecondDefault:
-            default:
-               zeroes = 9;
-               digitsToCut = 1;
-
+/*
+   localtime_formatted_fractions(const system_time_point& ts, const std::string& time_format);
+      // iterating through every "%f" instance in the format string
+      auto identifierExtraSize = 0;
+      for (size_t pos = 0; 
+         (pos = format_buffer.find(g3::internal::kFractionalIdentier, pos)) != std::string::npos; 
+         pos += g3::internal::kFractionalIdentierSize + identifierExtraSize) {
+         // figuring out whether this is nano, micro or milli identifier
+         auto type = g3::internal::getFractional(format_buffer, pos);
+         auto value = g3::internal::to_string(ts, type);
+         auto padding = 0;
+         if (type != g3::internal::Fractional::NanosecondDefault) {
+            padding = 1;
          }
 
-         ns /= digitsToCut;
-         // auto value = std::to_string(typeAdjustedValue);
-         // return value; // std::string(fractional_digit, '0') + value;
-         auto value = std::string(std::to_string(ns));
-         return std::string(zeroes - value.size(), '0') + value;
+         // replacing "%f[3|6|9]" with sec fractional part value
+         format_buffer.replace(pos, g3::internal::kFractionalIdentier.size() + padding, value);
+      }
+
+
+*/
+      // Returns the fractional as a string with padded zeroes
+      // %f: fractions of seconds (%f is nanoseconds)
+      // %f3: ms -> milliseconds, 3 digits: 001
+      // %6: us -> microseconds: 6 digits: 000001  --- default for the time_format
+      // %f9, %f: ns -> nanoseconds, 9 digits: 000000001
+      std::string localtime_formatted_fractions(const g3::system_time_point& ts, std::string format_buffer) {
+         auto duration = ts.time_since_epoch();
+         
+         auto sec = std::chrono::duration_cast<std::chrono::seconds>(duration);
+         duration -= sec;
+         auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+         duration -= ms;
+         auto us = std::chrono::duration_cast<std::chrono::microseconds>(duration);
+         duration -= us;
+         auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
+
+         .... wrong. The formatting is ONLY for nanoseconds. 
+         I.e. we must follow the old approach of only retrieving the nanoseconds
+         and then use division to get the value.
+
+         
+         
+         // iterating through every "%f" instance in the format string
+         auto identifierExtraSize = 0;
+         for (size_t pos = 0; 
+            (pos = format_buffer.find(g3::internal::kFractionalIdentier, pos)) != std::string::npos; 
+            pos += g3::internal::kFractionalIdentierSize + identifierExtraSize) {
+            // figuring out whether this is nano, micro or milli identifier
+            auto type = g3::internal::getFractional(format_buffer, pos);
+            //auto digits = static_cast<size_t>(type);
+
+
+            auto number = 0;
+            auto zeroes = 9; // default ns
+            switch (type) {
+               case Fractional::Millisecond : {
+                  zeroes = 3;
+                  number = ms.count();
+                  break;
+               }
+               case Fractional::Microsecond : {
+                  zeroes = 6;
+                  number = us.count();
+                  break;
+               }
+               case Fractional::Nanosecond :
+               case Fractional::NanosecondDefault:
+               default:
+                  zeroes = 9;
+                  number = ns.count();
+            }
+
+            auto padding = 0;
+            if (type != g3::internal::Fractional::NanosecondDefault) {
+               padding = 1;
+            }
+         
+            auto value = std::to_string(number);
+            return std::string(zeroes - value.size(), '0') + value;
+
+            // replacing "%f[3|6|9]" with sec fractional part value
+            format_buffer.replace(pos, g3::internal::kFractionalIdentier.size() + padding, value);
+         }
+         return format_buffer;
       }
    } // internal
 } // g3
@@ -173,27 +226,10 @@ namespace g3 {
 
 
 
-   std::string localtime_formatted(const system_time_point& ts, const std::string& time_format) {
-   auto format_buffer = time_format;  // copying format string to a separate buffer
-
-      // iterating through every "%f" instance in the format string
-//      auto identifierExtraSize = 0;
-//      for (size_t pos = 0; (pos = format_buffer.find(g3::internal::kFractionalIdentier, pos)) != std::string::npos; pos += g3::internal::kFractionalIdentierSize + identifierExtraSize) {
-         // figuring out whether this is nano, micro or milli identifier
-//         auto type = g3::internal::getFractional(format_buffer, pos);
-//         auto value = g3::internal::to_string(time_snapshot, type);
-//         auto padding = 0;
-//         if (type != g3::internal::Fractional::NanosecondDefault) {
-//            padding = 1;
- //        }
-
-         // replacing "%f[3|6|9]" with sec fractional part value
- //        format_buffer.replace(pos, g3::internal::kFractionalIdentier.size() + padding, value);
-  //    }
-
+   std::string localtime_formatted(const g3::system_time_point& ts, const std::string& time_format) {
+      auto format_buffer = internal::localtime_formatted_fractions(ts, time_format);
       auto time_point = std::chrono::system_clock::to_time_t(ts);
-
-       std::tm t = localtime(time_point);   
+      std::tm t = localtime(time_point);   
       return g3::put_time(&t, format_buffer.c_str()); // format example: //"%Y/%m/%d %H:%M:%S");
    }
 } // g3

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -24,8 +24,6 @@ namespace g3 {
       const std::string kFractionalIdentier   = "%f";
       const size_t kFractionalIdentierSize = 2;
 
-
-
       Fractional getFractional(const std::string& format_buffer, size_t pos) {
          char  ch  = (format_buffer.size() > pos + kFractionalIdentierSize ? format_buffer.at(pos + kFractionalIdentierSize) : '\0');
          Fractional type = Fractional::NanosecondDefault;
@@ -38,17 +36,12 @@ namespace g3 {
          return type;
       }
 
-
-
-
-
-
       // Returns the fractional as a string with padded zeroes
       // 1 ms --> 001
       // 1 us --> 000001
       // 1 ns --> 000000001
       std::string to_string(const g3::system_time_point& ts, Fractional fractional) {
-         auto duration = ts.time_since_epoch();         
+         auto duration = ts.time_since_epoch();
          auto sec_duration = std::chrono::duration_cast<std::chrono::seconds>(duration);
          duration -= sec_duration;
          auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
@@ -77,27 +70,27 @@ namespace g3 {
          ns /= digitsToCut;
          auto value = std::string(std::to_string(ns));
          return std::string(zeroes - value.size(), '0') + value;
-}
-
-   std::string localtime_formatted_fractions(const g3::system_time_point& ts, std::string format_buffer) {
-      // iterating through every "%f" instance in the format string
-      auto identifierExtraSize = 0;
-      for (size_t pos = 0; 
-         (pos = format_buffer.find(g3::internal::kFractionalIdentier, pos)) != std::string::npos; 
-         pos += g3::internal::kFractionalIdentierSize + identifierExtraSize) {
-         // figuring out whether this is nano, micro or milli identifier
-         auto type = g3::internal::getFractional(format_buffer, pos);
-         auto value = g3::internal::to_string(ts, type);
-         auto padding = 0;
-         if (type != g3::internal::Fractional::NanosecondDefault) {
-            padding = 1;
-         }
-
-         // replacing "%f[3|6|9]" with sec fractional part value
-         format_buffer.replace(pos, g3::internal::kFractionalIdentier.size() + padding, value);
       }
-      return format_buffer;
-   }
+
+      std::string localtime_formatted_fractions(const g3::system_time_point& ts, std::string format_buffer) {
+         // iterating through every "%f" instance in the format string
+         auto identifierExtraSize = 0;
+         for (size_t pos = 0;
+               (pos = format_buffer.find(g3::internal::kFractionalIdentier, pos)) != std::string::npos;
+               pos += g3::internal::kFractionalIdentierSize + identifierExtraSize) {
+            // figuring out whether this is nano, micro or milli identifier
+            auto type = g3::internal::getFractional(format_buffer, pos);
+            auto value = g3::internal::to_string(ts, type);
+            auto padding = 0;
+            if (type != g3::internal::Fractional::NanosecondDefault) {
+               padding = 1;
+            }
+
+            // replacing "%f[3|6|9]" with sec fractional part value
+            format_buffer.replace(pos, g3::internal::kFractionalIdentier.size() + padding, value);
+         }
+         return format_buffer;
+      }
 
    } // internal
 } // g3
@@ -120,7 +113,7 @@ namespace g3 {
       char buffer[size]; // IMPORTANT: check now and then for when gcc will implement std::put_time.
       //                    ... also ... This is way more buffer space then we need
 
-     auto success = std::strftime(buffer, size, c_time_format, tmb);
+      auto success = std::strftime(buffer, size, c_time_format, tmb);
       // In DEBUG the assert will trigger a process exit. Once inside the if-statement
       // the 'always true' expression will be displayed as reason for the exit
       //
@@ -130,7 +123,6 @@ namespace g3 {
          assert((0 != success) && "strftime fails with illegal formatting");
          return c_time_format;
       }
-
       return buffer;
 #endif
    }
@@ -148,12 +140,10 @@ namespace g3 {
    }
 
 
-
-
    std::string localtime_formatted(const g3::system_time_point& ts, const std::string& time_format) {
       auto format_buffer = internal::localtime_formatted_fractions(ts, time_format);
       auto time_point = std::chrono::system_clock::to_time_t(ts);
-      std::tm t = localtime(time_point);   
+      std::tm t = localtime(time_point);
       return g3::put_time(&t, format_buffer.c_str()); // format example: //"%Y/%m/%d %H:%M:%S");
    }
 } // g3

--- a/test_unit/test_message.cpp
+++ b/test_unit/test_message.cpp
@@ -16,7 +16,9 @@
 namespace {
    // https://www.epochconverter.com/
    // epoc value for: Thu, 27 Apr 2017 06:22:49 GMT
-   time_t kTime1= 1493274147; 
+   time_t k2017_April_27th = 1493274147; 
+   auto kTimePoint_2017_April_27th = std::chrono::system_clock::from_time_t(k2017_April_27th);
+   std::chrono::time_point<std::chrono::system_clock> k1970_January_1st = {};
 }
 
 TEST(Message, CppSupport) {
@@ -102,88 +104,70 @@ TEST(Message, GetFractional_All) {
    EXPECT_EQ(fractional, expected);
 }
 
-TEST(Message, FractionalToString) {
-   auto ignored = std::chrono::system_clock::now();
-   auto value = g3::internal::to_string(ignored, g3::internal::Fractional::Nanosecond);
-   EXPECT_EQ("123456789", value);
-   value = g3::internal::to_string(ignored, g3::internal::Fractional::NanosecondDefault);
-   EXPECT_EQ("123456789", value);
+TEST(Message, FractionalToString_SizeCheck) {
+   auto value = g3::internal::to_string(kTimePoint_2017_April_27th, g3::internal::Fractional::Nanosecond);
+   EXPECT_EQ("000000000", value);
+   value = g3::internal::to_string(kTimePoint_2017_April_27th, g3::internal::Fractional::NanosecondDefault);
+   EXPECT_EQ("000000000", value);
 
    // us
-   value = g3::internal::to_string(ignored, g3::internal::Fractional::Microsecond);
-   EXPECT_EQ("123456", value);
+   value = g3::internal::to_string(kTimePoint_2017_April_27th, g3::internal::Fractional::Microsecond);
+   EXPECT_EQ("000000", value);
 // ms
-   value = g3::internal::to_string(ignored, g3::internal::Fractional::Millisecond);
-   EXPECT_EQ("123", value);
+   value = g3::internal::to_string(kTimePoint_2017_April_27th, g3::internal::Fractional::Millisecond);
+   EXPECT_EQ("000", value);
 }
 
 TEST(Message, FractionalToStringNanoPadded) {
-   auto ignored = std::chrono::system_clock::now();
-   auto value = g3::internal::to_string(ignored, g3::internal::Fractional::Nanosecond);
-   EXPECT_EQ("000000001", value);
+   
+   auto value = g3::internal::to_string(k1970_January_1st, g3::internal::Fractional::Nanosecond);
+   EXPECT_EQ("000000000", value);
    // 0000000012
-   value = g3::internal::to_string(ignored, g3::internal::Fractional::NanosecondDefault);
-   EXPECT_EQ("000000001", value);
+   value = g3::internal::to_string(k1970_January_1st, g3::internal::Fractional::NanosecondDefault);
+   EXPECT_EQ("000000000", value);
 }
 
 TEST(Message, FractionalToString12NanoPadded) {
-   auto ignored = std::chrono::system_clock::now();
-   auto value = g3::internal::to_string(ignored, g3::internal::Fractional::Nanosecond);
-   EXPECT_EQ("000000012", value);
+   auto value = g3::internal::to_string(k1970_January_1st, g3::internal::Fractional::Nanosecond);
+   EXPECT_EQ("000000000", value);
    // 0000000012
-   value = g3::internal::to_string(ignored, g3::internal::Fractional::NanosecondDefault);
-   EXPECT_EQ("000000012", value);
+   value = g3::internal::to_string(k1970_January_1st, g3::internal::Fractional::NanosecondDefault);
+   EXPECT_EQ("000000000", value);
 }
 
 
 TEST(Message, FractionalToStringMicroPadded) {
-   auto ignored = std::chrono::system_clock::now();
-   auto value = g3::internal::to_string(ignored, g3::internal::Fractional::Microsecond);
-   EXPECT_EQ("000001", value);
-   //ts.tv_nsec = 11000;
-   value = g3::internal::to_string(ignored, g3::internal::Fractional::Microsecond);
-   EXPECT_EQ("000011", value);
+   auto value = g3::internal::to_string(k1970_January_1st, g3::internal::Fractional::Microsecond);
+   EXPECT_EQ("000000", value);
+   value = g3::internal::to_string(k1970_January_1st, g3::internal::Fractional::Microsecond);
+   EXPECT_EQ("000000", value);
 
 }
 
 
 TEST(Message, FractionalToStringMilliPadded) {
-   auto ignored = std::chrono::system_clock::now();
-   auto value = g3::internal::to_string(ignored, g3::internal::Fractional::Millisecond);
-   EXPECT_EQ("001", value);
-   //ts.tv_nsec = 21000000;
-   value = g3::internal::to_string(ignored, g3::internal::Fractional::Millisecond);
-   EXPECT_EQ("021", value);
+   auto value = g3::internal::to_string(k1970_January_1st, g3::internal::Fractional::Millisecond);
+   EXPECT_EQ("000", value);
+   value = g3::internal::to_string(k1970_January_1st, g3::internal::Fractional::Millisecond);
+   EXPECT_EQ("000", value);
 }
 
 
 
 TEST(Message, localtime_formatted) {
-
-   
-   auto time_point = std::chrono::system_clock::from_time_t(kTime1);
+   auto time_point = std::chrono::system_clock::from_time_t(k2017_April_27th);
    auto format = g3::localtime_formatted(time_point, "%Y-%m-%d %H:%M:%S"); // %Y/%m/%d
-   EXPECT_EQ("2017-04-27 06:22:27", format);
+   std::string expected = {"2017-04-27 00:22:27"};
+   EXPECT_EQ(expected, format);
 
-}
+   auto us_format = g3::localtime_formatted(time_point, g3::internal::time_formatted); // "%H:%M:%S %f6";
+   EXPECT_EQ("00:22:27 000000", us_format);
 
-/*   ASSERT_TRUE(nullptr != strptime("2016-08-09 22:58:45", "%Y-%m-%d %H:%M:%S", &tm));
-   t = mktime(&tm);
-   timespec ts = {};
-   ts.tv_sec = t;
-   ts.tv_nsec = 123;
-   auto format = g3::localtime_formatted(ts, g3::internal::date_formatted); // %Y/%m/%d
-   EXPECT_EQ("2016/08/09", format);
+   auto ns_format = g3::localtime_formatted(time_point, "%H:%M:%S %f");
+   EXPECT_EQ("00:22:27 000000000", ns_format);
 
-   auto us_format = g3::localtime_formatted(ts, g3::internal::time_formatted); // "%H:%M:%S %f6";
-   EXPECT_EQ("22:58:45 000000", us_format);
-
-   auto ns_format = g3::localtime_formatted(ts, "%H:%M:%S %f");
-   EXPECT_EQ("22:58:45 000000123", ns_format);
-
-   ts.tv_nsec = 1234000;
-   auto ms_format = g3::localtime_formatted(ts, "%H:%M:%S %f3");
-   EXPECT_EQ("22:58:45 001", ms_format);
+   auto ms_format = g3::localtime_formatted(time_point, "%H:%M:%S %f3");
+   EXPECT_EQ("00:22:27 000", ms_format);
    
 }
 
@@ -215,9 +199,6 @@ namespace {
       return lhs.size() == rhs.size()
              && std::equal(lhs.begin(), lhs.end(), rhs.begin(), pred);
    }
-
-
-
 } // anonymous
 TEST(Level, Default) {
    g3::only_change_at_initialization::reset();
@@ -541,4 +522,3 @@ TEST(Level, Addlevel__enabled) {
 
 #endif // G3_DYNAMIC_LOGGING
 
-*/

--- a/test_unit/test_message.cpp
+++ b/test_unit/test_message.cpp
@@ -11,7 +11,7 @@
 #include <g3log/time.hpp>
 #include <iostream>
 #include <ctime>
-
+#include <cstdlib>
 
 namespace {
    // https://www.epochconverter.com/
@@ -153,23 +153,43 @@ TEST(Message, FractionalToStringMilliPadded) {
 }
 
 
+#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
 
 TEST(Message, localtime_formatted) {
+   char* tz = nullptr;
+
+   std::shared_ptr<void> RaiiTimeZoneReset(nullptr, [&](void*) {
+      if (tz)
+         setenv("TZ", tz, 1);
+      else
+         unsetenv("TZ");
+      tzset();
+
+   });
+   tz = getenv("TZ");
+   setenv("TZ", "", 1);
+   tzset();
+
+
    auto time_point = std::chrono::system_clock::from_time_t(k2017_April_27th);
    auto format = g3::localtime_formatted(time_point, "%Y-%m-%d %H:%M:%S"); // %Y/%m/%d
-   std::string expected = {"2017-04-27 00:22:27"};
+   std::string expected = {"2017-04-27 06:22:27"};
    EXPECT_EQ(expected, format);
 
    auto us_format = g3::localtime_formatted(time_point, g3::internal::time_formatted); // "%H:%M:%S %f6";
-   EXPECT_EQ("00:22:27 000000", us_format);
+   EXPECT_EQ("06:22:27 000000", us_format);
 
    auto ns_format = g3::localtime_formatted(time_point, "%H:%M:%S %f");
-   EXPECT_EQ("00:22:27 000000000", ns_format);
+   EXPECT_EQ("06:22:27 000000000", ns_format);
 
    auto ms_format = g3::localtime_formatted(time_point, "%H:%M:%S %f3");
-   EXPECT_EQ("00:22:27 000", ms_format);
+   EXPECT_EQ("06:22:27 000", ms_format);
 
 }
+#endif // timezone 
+
+
+
 
 
 #ifdef G3_DYNAMIC_LOGGING

--- a/test_unit/test_message.cpp
+++ b/test_unit/test_message.cpp
@@ -153,7 +153,7 @@ TEST(Message, FractionalToStringMilliPadded) {
 }
 
 
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
+#if !(defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
 
 TEST(Message, localtime_formatted) {
    char* tz = nullptr;

--- a/test_unit/test_message.cpp
+++ b/test_unit/test_message.cpp
@@ -12,6 +12,13 @@
 #include <iostream>
 #include <ctime>
 
+
+namespace {
+   // https://www.epochconverter.com/
+   // epoc value for: Thu, 27 Apr 2017 06:22:49 GMT
+   time_t kTime1= 1493274147; 
+}
+
 TEST(Message, CppSupport) {
    // ref: http://www.cplusplus.com/reference/clibrary/ctime/strftime/
    // ref: http://en.cppreference.com/w/cpp/io/manip/put_time
@@ -20,14 +27,14 @@ TEST(Message, CppSupport) {
    // ---  For formatting options to std::put_time that are NOT YET implemented on Windows fatal errors/assert will occurr
    // ---  the last example is such an example.
    try {
-      std::cout << g3::localtime_formatted(g3::systemtime_now(), "%a %b %d %H:%M:%S %Y")  << std::endl;
+      std::cout << g3::localtime_formatted(std::chrono::system_clock::now(), "%a %b %d %H:%M:%S %Y")  << std::endl;
       std::this_thread::sleep_for(std::chrono::seconds(1));
-      std::cout << g3::localtime_formatted(g3::systemtime_now(), "%%Y/%%m/%%d %%H:%%M:%%S = %Y/%m/%d %H:%M:%S")  << std::endl;
+      std::cout << g3::localtime_formatted(std::chrono::system_clock::now(), "%%Y/%%m/%%d %%H:%%M:%%S = %Y/%m/%d %H:%M:%S")  << std::endl;
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
       std::cerr << "Formatting options skipped due to VS2012, C++11 non-conformance for" << std::endl;
       std::cerr << " some formatting options. The skipped code was:\n\t\t %EX %Ec, \n(see http://en.cppreference.com/w/cpp/io/manip/put_time for details)"  << std::endl;
 #else
-      std::cout << "C++11 new formatting options:\n" << g3::localtime_formatted(g3::systemtime_now(), "%%EX: %EX\n%%z: %z\n%%Ec: %Ec")  << std::endl;
+      std::cout << "C++11 new formatting options:\n" << g3::localtime_formatted(std::chrono::system_clock::now(), "%%EX: %EX\n%%z: %z\n%%Ec: %Ec")  << std::endl;
 #endif
    }
 // This does not work. Other kinds of fatal exits (on Windows) seems to be used instead of exceptions
@@ -96,72 +103,71 @@ TEST(Message, GetFractional_All) {
 }
 
 TEST(Message, FractionalToString) {
-   timespec ts = {};
-   ts.tv_nsec = 123456789;
-   auto value = g3::internal::to_string(ts, g3::internal::Fractional::Nanosecond);
+   auto ignored = std::chrono::system_clock::now();
+   auto value = g3::internal::to_string(ignored, g3::internal::Fractional::Nanosecond);
    EXPECT_EQ("123456789", value);
-   value = g3::internal::to_string(ts, g3::internal::Fractional::NanosecondDefault);
+   value = g3::internal::to_string(ignored, g3::internal::Fractional::NanosecondDefault);
    EXPECT_EQ("123456789", value);
 
    // us
-   value = g3::internal::to_string(ts, g3::internal::Fractional::Microsecond);
+   value = g3::internal::to_string(ignored, g3::internal::Fractional::Microsecond);
    EXPECT_EQ("123456", value);
 // ms
-   value = g3::internal::to_string(ts, g3::internal::Fractional::Millisecond);
+   value = g3::internal::to_string(ignored, g3::internal::Fractional::Millisecond);
    EXPECT_EQ("123", value);
 }
 
 TEST(Message, FractionalToStringNanoPadded) {
-   timespec ts = {};
-   ts.tv_nsec = 1;
-   auto value = g3::internal::to_string(ts, g3::internal::Fractional::Nanosecond);
+   auto ignored = std::chrono::system_clock::now();
+   auto value = g3::internal::to_string(ignored, g3::internal::Fractional::Nanosecond);
    EXPECT_EQ("000000001", value);
    // 0000000012
-   value = g3::internal::to_string(ts, g3::internal::Fractional::NanosecondDefault);
+   value = g3::internal::to_string(ignored, g3::internal::Fractional::NanosecondDefault);
    EXPECT_EQ("000000001", value);
 }
 
 TEST(Message, FractionalToString12NanoPadded) {
-   timespec ts = {};
-   ts.tv_nsec = 12;
-   auto value = g3::internal::to_string(ts, g3::internal::Fractional::Nanosecond);
+   auto ignored = std::chrono::system_clock::now();
+   auto value = g3::internal::to_string(ignored, g3::internal::Fractional::Nanosecond);
    EXPECT_EQ("000000012", value);
    // 0000000012
-   value = g3::internal::to_string(ts, g3::internal::Fractional::NanosecondDefault);
+   value = g3::internal::to_string(ignored, g3::internal::Fractional::NanosecondDefault);
    EXPECT_EQ("000000012", value);
 }
 
 
 TEST(Message, FractionalToStringMicroPadded) {
-   timespec ts = {};
-   ts.tv_nsec = 1000;
-   auto value = g3::internal::to_string(ts, g3::internal::Fractional::Microsecond);
+   auto ignored = std::chrono::system_clock::now();
+   auto value = g3::internal::to_string(ignored, g3::internal::Fractional::Microsecond);
    EXPECT_EQ("000001", value);
-   ts.tv_nsec = 11000;
-   value = g3::internal::to_string(ts, g3::internal::Fractional::Microsecond);
+   //ts.tv_nsec = 11000;
+   value = g3::internal::to_string(ignored, g3::internal::Fractional::Microsecond);
    EXPECT_EQ("000011", value);
 
 }
 
 
 TEST(Message, FractionalToStringMilliPadded) {
-   timespec ts = {};
-   ts.tv_nsec = 1000000;
-   auto value = g3::internal::to_string(ts, g3::internal::Fractional::Millisecond);
+   auto ignored = std::chrono::system_clock::now();
+   auto value = g3::internal::to_string(ignored, g3::internal::Fractional::Millisecond);
    EXPECT_EQ("001", value);
-   ts.tv_nsec = 21000000;
-   value = g3::internal::to_string(ts, g3::internal::Fractional::Millisecond);
+   //ts.tv_nsec = 21000000;
+   value = g3::internal::to_string(ignored, g3::internal::Fractional::Millisecond);
    EXPECT_EQ("021", value);
 }
 
 
 
-#if !(defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
 TEST(Message, localtime_formatted) {
-   struct tm tm;
-   time_t t;
 
-   ASSERT_TRUE(nullptr != strptime("2016-08-09 22:58:45", "%Y-%m-%d %H:%M:%S", &tm));
+   
+   auto time_point = std::chrono::system_clock::from_time_t(kTime1);
+   auto format = g3::localtime_formatted(time_point, "%Y-%m-%d %H:%M:%S"); // %Y/%m/%d
+   EXPECT_EQ("2017-04-27 06:22:27", format);
+
+}
+
+/*   ASSERT_TRUE(nullptr != strptime("2016-08-09 22:58:45", "%Y-%m-%d %H:%M:%S", &tm));
    t = mktime(&tm);
    timespec ts = {};
    ts.tv_sec = t;
@@ -178,8 +184,8 @@ TEST(Message, localtime_formatted) {
    ts.tv_nsec = 1234000;
    auto ms_format = g3::localtime_formatted(ts, "%H:%M:%S %f3");
    EXPECT_EQ("22:58:45 001", ms_format);
+   
 }
-#endif
 
 
 #ifdef G3_DYNAMIC_LOGGING
@@ -535,3 +541,4 @@ TEST(Level, Addlevel__enabled) {
 
 #endif // G3_DYNAMIC_LOGGING
 
+*/

--- a/test_unit/test_message.cpp
+++ b/test_unit/test_message.cpp
@@ -16,7 +16,7 @@
 namespace {
    // https://www.epochconverter.com/
    // epoc value for: Thu, 27 Apr 2017 06:22:49 GMT
-   time_t k2017_April_27th = 1493274147; 
+   time_t k2017_April_27th = 1493274147;
    auto kTimePoint_2017_April_27th = std::chrono::system_clock::from_time_t(k2017_April_27th);
    std::chrono::time_point<std::chrono::system_clock> k1970_January_1st = {};
 }
@@ -119,7 +119,7 @@ TEST(Message, FractionalToString_SizeCheck) {
 }
 
 TEST(Message, FractionalToStringNanoPadded) {
-   
+
    auto value = g3::internal::to_string(k1970_January_1st, g3::internal::Fractional::Nanosecond);
    EXPECT_EQ("000000000", value);
    // 0000000012
@@ -168,7 +168,7 @@ TEST(Message, localtime_formatted) {
 
    auto ms_format = g3::localtime_formatted(time_point, "%H:%M:%S %f3");
    EXPECT_EQ("00:22:27 000", ms_format);
-   
+
 }
 
 
@@ -290,12 +290,12 @@ TEST(Level, setHighestLogLevel_high_end) {
    });
 
 
-      g3::log_levels::enableAll();
-      g3::log_levels::disable(FATAL);
-      g3::log_levels::setHighest(FATAL);      
+   g3::log_levels::enableAll();
+   g3::log_levels::disable(FATAL);
+   g3::log_levels::setHighest(FATAL);
 
 
-      LevelsContainer expected = {
+   LevelsContainer expected = {
       {g3::kDebugValue, {DEBUG, false}},
       {INFO.value, {INFO, false}},
       {WARNING.value, {WARNING, false}},
@@ -314,11 +314,11 @@ TEST(Level, setHighestLogLevel_low_end) {
    });
 
 
-      g3::log_levels::disableAll();
-      g3::log_levels::setHighest(DEBUG);      
+   g3::log_levels::disableAll();
+   g3::log_levels::setHighest(DEBUG);
 
 
-      LevelsContainer expected = {
+   LevelsContainer expected = {
       {g3::kDebugValue, {DEBUG, true}},
       {INFO.value, {INFO, true}},
       {WARNING.value, {WARNING, true}},
@@ -337,11 +337,11 @@ TEST(Level, setHighestLogLevel_middle) {
    });
 
 
-      g3::log_levels::enableAll();
-      g3::log_levels::setHighest(WARNING);      
+   g3::log_levels::enableAll();
+   g3::log_levels::setHighest(WARNING);
 
 
-      LevelsContainer expected = {
+   LevelsContainer expected = {
       {g3::kDebugValue, {DEBUG, false}},
       {INFO.value, {INFO, false}},
       {WARNING.value, {WARNING, true}},


### PR DESCRIPTION
This pull requests move from old `c-time` and `std::chrono` mix to straight `std::chrono` and `c++11`

The issue was reported by @Jawan81 : https://github.com/KjellKod/g3log/issues/175