### PR TITLE
Fix git version check for cross-compiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ endif()
 
 SET(MAJOR_VERSION 1)
 IF (${VERSION}.x STREQUAL ".x")
-   IF (MSVC)
+   IF ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
       message("windows: Extracting git software version")
       execute_process(COMMAND powershell "(git rev-list --branches HEAD | Measure-Object -line).Lines" OUTPUT_VARIABLE GIT_VERSION WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
    ELSE()

--- a/test_unit/Test.cmake
+++ b/test_unit/Test.cmake
@@ -74,7 +74,7 @@
        add_library(tester_sharedlib SHARED ${DIR_UNIT_TEST}/tester_sharedlib.h ${DIR_UNIT_TEST}/tester_sharedlib.cpp)
        target_link_libraries(tester_sharedlib ${G3LOG_LIBRARY})
 
-       add_executable(test_dynamic_loaded_shared_lib ../test_main/test_main.cpp ${DIR_UNIT_TEST}/test_linux_dynamic_loaded_sharedlib.cpp)
+       add_executable(test_dynamic_loaded_shared_lib ${g3log_SOURCE_DIR}/test_main/test_main.cpp ${DIR_UNIT_TEST}/test_linux_dynamic_loaded_sharedlib.cpp)
        set_target_properties(test_dynamic_loaded_shared_lib PROPERTIES COMPILE_DEFINITIONS "GTEST_HAS_TR1_TUPLE=0")
        set_target_properties(test_dynamic_loaded_shared_lib PROPERTIES COMPILE_DEFINITIONS "GTEST_HAS_RTTI=0")
        target_link_libraries(test_dynamic_loaded_shared_lib  ${G3LOG_LIBRARY} -ldl  gtest_170_lib )


### PR DESCRIPTION
Small addition to cmake-changes2: When cross compiling MSVC is of course not set on windows. Also it just checks whether using the MS compiler - will also not be set for mingw. Thus checking for the host OS and thus determining on which system the command is run on seems the way to go.