### PR TITLE
macros now properly set before compiling implementation files

### DIFF
--- a/GenerateMacroDefinitionsFile.cmake
+++ b/GenerateMacroDefinitionsFile.cmake
@@ -30,6 +30,10 @@ FILE(APPEND ${GENERATED_G3_DEFINITIONS} "// CMake induced definitions below. See
 
 FOREACH(definition ${G3_DEFINITIONS} )
    FILE(APPEND ${GENERATED_G3_DEFINITIONS} "#define ${definition}\n")
+   if(definition MATCHES ".* .*")
+   else()
+       add_definitions(-D${definition})
+   endif()
 ENDFOREACH(definition)
 
 MESSAGE("Generated ${GENERATED_G3_DEFINITIONS}")


### PR DESCRIPTION
addresses issue #194 

The macros generated by the CMake file would not be seen during the compilation process of the source files.

This would lead to undefined reference linking errors when trying to use methods such as `g3::log_levels::setHighest(LEVELS)` since the appropriate macros such as `G3_DYNAMIC_LOGGING` would not be defined.

This is a quick fix to resolve this issue. It is not very elegant, so may be worth looking for an alternative solution but this solved it for me.