### PR TITLE
Add in setMaxMessageSize (#203)

### DIFF
--- a/src/g3log/g3log.hpp
+++ b/src/g3log/g3log.hpp
@@ -86,7 +86,14 @@ namespace g3 {
    void setFatalExitHandler(std::function<void(FatalMessagePtr)> fatal_call);
 
 
-
+   // only_change_at_initialization namespace is for changes to be done only during initialization. More specifically
+   // items here would be called prior to calling other parts of g3log
+   namespace only_change_at_initialization {
+      // Sets the MaxMessageSize to be used when capturing log messages. Currently this value is set to 2KB. Messages
+      // Longer than this are bound to 2KB with the string "[...truncated...]" at the end. This function allows
+      // this limit to be changed.
+      void setMaxMessageSize(size_t max_size);
+   }
 
    // internal namespace is for completely internal or semi-hidden from the g3 namespace due to that it is unlikely
    // that you will use these

--- a/src/logcapture.cpp
+++ b/src/logcapture.cpp
@@ -19,6 +19,12 @@
 #define SIGNAL_HANDLER_VERIFY() do {} while(0)
 #endif
 
+// MaxMessageSize is message limit used with vsnprintf/vsnprintf_s
+static int MaxMessageSize = 2048;
+
+void g3::only_change_at_initialization::setMaxMessageSize(size_t max_size) {
+   MaxMessageSize = max_size;
+}
 
 
 /** logCapture is a simple struct for capturing log/fatal entries. At destruction the
@@ -60,9 +66,8 @@ LogCapture::LogCapture(const char *file, const int line, const char *function, c
 * See also for the attribute formatting ref:  http://www.codemaestro.com/reviews/18
 */
 void LogCapture::capturef(const char *printf_like_message, ...) {
-   static const int kMaxMessageSize = 2048;
    static const std::string kTruncatedWarningText = "[...truncated...]";
-   char finished_message[kMaxMessageSize];
+   char finished_message[MaxMessageSize];
    va_list arglist;
    va_start(arglist, printf_like_message);
 
@@ -76,7 +81,7 @@ void LogCapture::capturef(const char *printf_like_message, ...) {
    if (nbrcharacters <= 0) {
       stream() << "\n\tERROR LOG MSG NOTIFICATION: Failure to parse successfully the message";
       stream() << '"' << printf_like_message << '"' << std::endl;
-   } else if (nbrcharacters > kMaxMessageSize) {
+   } else if (nbrcharacters > MaxMessageSize) {
       stream() << finished_message << kTruncatedWarningText;
    } else {
       stream() << finished_message;

--- a/src/logcapture.cpp
+++ b/src/logcapture.cpp
@@ -23,7 +23,7 @@
 static int MaxMessageSize = 2048;
 
 void g3::only_change_at_initialization::setMaxMessageSize(size_t max_size) {
-   MaxMessageSize = max_size;
+   MaxMessageSize = static_cast<int>(max_size);
 }
 
 


### PR DESCRIPTION
I was going to try and do a unit test, but it only runs on Linux and I'm on a Mac so I couldn't build.

I figured the easiest way to test was to create a sink that understands how to find the ```[...truncated...]``` at the end, which could then be used to verify if we were truncated or not.

I did test this in my current code (both in the client and server). Client is iOS. Server is MacOS.

My tests included:

-Creating a string of 2048 characters using ```std::string(2048, 'A')```. Verify this works
-Created a string of 2049 characters and verify it prints out the ```[...truncated...]```

I then called ```g3::only_change_at_initialization::setMaxMessageSize(200)```

I run the similar tests above (using 200 and 201)

I then called ```g3::only_change_at_initialization::setMaxMessageSize(16000)```

I run the similar tests above (using 16000 and 16001)

It all checked out. Hopefully that is sufficient in testing. 
