### PR TITLE
Add in support for configurable kMaxMessageValue #203

### DIFF
--- a/API.markdown
+++ b/API.markdown
@@ -9,6 +9,7 @@ Most of the API that you need for using g3log is described in this readme. For m
 * Sink [creation](#sink_creation) and utilization 
 * LOG [flushing](#log_flushing)
 * G3log and G3Sinks [usage example](#g3log-and-sink-usage-code-example)
+* Support for [dynamic message sizing](#dynamic_message_sizing)
 * Fatal handling
   * [Linux/*nix](#fatal_handling_linux)
   * <strike>[TOWRITE: Windows](#fatal_handling_windows)</strike>
@@ -156,6 +157,20 @@ int main(int argc, char**argv) {
    // this example
    g3::shutDownLogging();
 }
+```
+
+
+## Dynamic Message Sizing <a name="dynamic_message_sizing"></a>
+The default build uses a fixed size buffer for formatting messages. The size of this buffer is 2048 bytes. If an incoming message results in a formatted message that is greater than 2048 bytes, it will be bound to 2048 bytes and will have the string ```[...truncated...]``` appended to the end of the bound message. There are cases where one would like to dynamically change the size at runtime. For example, when debugging payloads for a server, it may be desirable to handle larger message sizes in order to examine the whole payload. Rather than forcing the developer to rebuild the server, dynamic message sizing could be used along with a config file which defines the message size at runtime.
+
+This feature supported as a CMake option:
+
+**CMake option: (default OFF)** ```cmake -DUSE_G3_DYNAMIC_MAX_MESSAGE_SIZE=ON ..```
+
+The following is an example of changing the size for the message.
+
+```
+    g3::only_change_at_initialization::setMaxMessageSize(10000);
 ```
 
 

--- a/Options.cmake
+++ b/Options.cmake
@@ -17,6 +17,7 @@
 #   add_definitions(-DDISABLE_FATAL_SIGNALHANDLING)
 #   add_definitions(-DDISABLE_VECTORED_EXCEPTIONHANDLING)
 #   add_definitions(-DDEBUG_BREAK_AT_FATAL_SIGNAL)
+#   add_definitions(-DG3_DYNAMIC_MAX_MESSAGE_SIZE)
 
 
 
@@ -40,7 +41,6 @@ ENDIF(USE_DYNAMIC_LOGGING_LEVELS)
 
 
 
-
 # -DCHANGE_G3LOG_DEBUG_TO_DBUG=ON   : change the DEBUG logging level to be DBUG to avoid clash with other libraries that might have
 # predefined DEBUG for their own purposes
 option (CHANGE_G3LOG_DEBUG_TO_DBUG
@@ -54,6 +54,16 @@ ELSE()
    message( STATUS "-DCHANGE_G3LOG_DEBUG_TO_DBUG=OFF \t(Debuggin logging level is 'DEBUG')" ) 
 ENDIF(CHANGE_G3LOG_DEBUG_TO_DBUG)
 
+
+# -DG3_DYNAMIC_MAX_MESSAGE_SIZE   : use dynamic memory for final_message in logcapture.cpp
+option (USE_G3_DYNAMIC_MAX_MESSAGE_SIZE
+       "Use dynamic memory for message buffer during log capturing" OFF)
+IF(USE_G3_DYNAMIC_MAX_MESSAGE_SIZE)
+   LIST(APPEND G3_DEFINITIONS G3_DYNAMIC_MAX_MESSAGE_SIZE)
+   message( STATUS "-DUSE_G3_DYNAMIC_MAX_MESSAGE_SIZE=ON\t\tDynamic memory used during log capture" )
+ELSE()
+   message( STATUS "-DUSE_G3_DYNAMIC_MAX_MESSAGE_SIZE=OFF" )
+ENDIF(USE_G3_DYNAMIC_MAX_MESSAGE_SIZE)
 
 
 # -DENABLE_FATAL_SIGNALHANDLING=ON   : defualt change the

--- a/src/g3log/g3log.hpp
+++ b/src/g3log/g3log.hpp
@@ -86,7 +86,16 @@ namespace g3 {
    void setFatalExitHandler(std::function<void(FatalMessagePtr)> fatal_call);
 
 
-
+#ifdef G3_DYNAMIC_MAX_MESSAGE_SIZE
+  // only_change_at_initialization namespace is for changes to be done only during initialization. More specifically
+  // items here would be called prior to calling other parts of g3log
+  namespace only_change_at_initialization {
+    // Sets the MaxMessageSize to be used when capturing log messages. Currently this value is set to 2KB. Messages
+    // Longer than this are bound to 2KB with the string "[...truncated...]" at the end. This function allows
+    // this limit to be changed.
+    void setMaxMessageSize(size_t max_size);
+  }
+#endif /* G3_DYNAMIC_MAX_MESSAGE_SIZE */
 
    // internal namespace is for completely internal or semi-hidden from the g3 namespace due to that it is unlikely
    // that you will use these


### PR DESCRIPTION
Sorry for the delay in updating this. Hopefully this does it. Compile time option for this (default is the current static). Using ```std::vector<char>```.