### PR TITLE
atomicbool.hpp needs EOF outside of comment to build on VS15

### DIFF
--- a/src/g3log/atomicbool.hpp
+++ b/src/g3log/atomicbool.hpp
@@ -40,3 +40,4 @@ namespace g3 {
       std::atomic<bool>& get() {return value_;}
    };
 } // g3
+// explicit whitespace/EOF for VS15 


### PR DESCRIPTION
Sorry if I am doing this wrong Kjell, it is my first...

I am trying to use g3log, and everything is great on osx/xcode & linux/gcc, but (what a surprise) windows/VS feels the need to be different

It is simply fixed by adding a newline: I have no idea why VS does not understand the closure of the block, but it does not.
`} // g3'

...added

'// explicit whitespace/EOF for VS15 `
