### PR TITLE
Fixing some English/typos and a cyclical header include.

### DIFF
--- a/src/crashhandler_windows.cpp
+++ b/src/crashhandler_windows.cpp
@@ -77,7 +77,7 @@ namespace {
       trigger.stream() << fatal_stream.str();
 
       // Trigger debug break point, if we're in debug. This breakpoint CAN cause a slowdown when it happens.
-      // Be patient. The "Debug" dialogue should pop-up eventually if you doing it in Visual Studio.
+      // Be patient. The "Debug" dialog should pop-up eventually if you doing it in Visual Studio.
       // For fatal signals only, not exceptions.
       // This is a way to tell the IDE (if in dev mode) that it can stop at this breakpoint
       // Note that at this time the fatal log event with stack trace is NOT yet flushed to the logger
@@ -102,9 +102,9 @@ namespace {
       const auto fatal_id = static_cast<g3::SignalType>(exception_code);
       LogCapture trigger(g3::internal::FATAL_EXCEPTION, fatal_id, dump.c_str());
       trigger.stream() << fatal_stream.str();
-      // FATAL Exception: It doesn't necessarily stop here we pass on continue search
+      // FATAL Exception: It doesn't necessarily stop here. we pass on continue search
       // if no one else will catch that then it's goodbye anyhow.
-      // The RISK here is if someone is cathing this and returning "EXCEPTION_EXECUTE_HANDLER"
+      // The RISK here is if someone is catching this and returning "EXCEPTION_EXECUTE_HANDLER"
       // but does not shutdown then the software will be running with g3log shutdown.
       // .... However... this must be seen as a bug from standard handling of fatal exceptions
       // https://msdn.microsoft.com/en-us/library/6wxdsc38.aspx
@@ -192,7 +192,7 @@ namespace g3 {
          ReverseToOriginalFatalHandling();
          // For windows exceptions we want to continue the possibility of
          // exception handling now when the log and stacktrace are flushed
-         // to sinks. We therefore avoid to kill the preocess here. Instead
+         // to sinks. We therefore avoid to kill the process here. Instead
          //  it will be the exceptionHandling functions above that
          // will let exception handling continue with: EXCEPTION_CONTINUE_SEARCH
          if (g3::internal::FATAL_EXCEPTION == level) {
@@ -200,7 +200,7 @@ namespace g3 {
             return;
          }
 
-         // for a sigal however, we exit through that fatal signal
+         // for a signal however, we exit through that fatal signal
          const int signal_number = static_cast<int>(fatal_signal_id);
          raise(signal_number);
       }
@@ -243,8 +243,8 @@ namespace g3 {
 
 #if !(defined(DISABLE_VECTORED_EXCEPTIONHANDLING))
       // const size_t kFirstExceptionHandler = 1;
-      // kFirstExeptionsHandler is kept here for documentational purposes.
-      // The last exception seems more what we want
+      // kFirstExeptionsHandler is kept here for documentation purposes.
+      // The last exception seems more like what we want.
       const size_t kLastExceptionHandler = 0;
       g_vector_exception_handler = AddVectoredExceptionHandler(kLastExceptionHandler, vectorExceptionHandling);
 #endif

--- a/src/g3log/crashhandler.hpp
+++ b/src/g3log/crashhandler.hpp
@@ -31,7 +31,7 @@ namespace g3 {
 
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
    typedef unsigned long SignalType;
-   ///  SIGFPE, SIGILL, and SIGSEGV handling must be installed per thread
+   /// SIGFPE, SIGILL, and SIGSEGV handling must be installed per thread
    /// on Windows. This is automatically done if you do at least one LOG(...) call
    /// you can also use this function call, per thread so make sure these three
    /// fatal signals are covered in your thread (even if you don't do a LOG(...) call

--- a/src/g3log/g3log.hpp
+++ b/src/g3log/g3log.hpp
@@ -47,8 +47,8 @@
  * first commercial project to use it used 'g3' as an internal denominator for
  * the current project. g3 as in 'generation 2'. I decided to keep the g3 and g3log names
  * to give credit to the people in that project (you know who you are :) and I guess also
- * for 'sentimental' reasons. That a big influence was google's glog is just a happy
- *  concidence or subconscious choice. Either way g3log became the name for this logger.
+ * for 'sentimental' reasons. That a big influence was Google's glog is just a happy
+ * coincidence or subconscious choice. Either way g3log became the name for this logger.
  *
  * --- Thanks for a great 2011 and good luck with 'g3' --- KjellKod
  */
@@ -58,7 +58,7 @@ namespace g3 {
    struct FatalMessage;
 
    /** Should be called at very first startup of the software with \ref g3LogWorker
-    *  pointer. Ownership of the \ref g3LogWorker is the responsibilkity of the caller */
+    *  pointer. Ownership of the \ref g3LogWorker is the responsibility of the caller */
    void initializeLogging(LogWorker *logger);
 
 
@@ -114,14 +114,14 @@ namespace g3 {
       // forwards a FATAL message to all sinks,. after which the g3logworker
       // will trigger crashhandler / g3::internal::exitWithDefaultSignalHandler
       //
-      // By default the "fatalCall" will forward a Fatalessageptr to this function
-      // this behaviour can be changed if you set a different fatal handler through
+      // By default the "fatalCall" will forward a FatalMessageptr to this function
+      // this behavior can be changed if you set a different fatal handler through
       // "setFatalExitHandler"
       void pushFatalMessageToLogger(FatalMessagePtr message);
 
 
-      // Save the created FatalMessage to any existing sinks and exit with
-      // the originating fatal signal,. or SIGABRT if it originated from a broken contract
+      // Saves the created FatalMessage to any existing sinks and exits with
+      // the originating fatal signal,. or SIGABRT if it originated from a broken contract.
       // By default forwards to: pushFatalMessageToLogger, see "setFatalExitHandler" to override
       //
       // If you override it then you probably want to call "pushFatalMessageToLogger" after your

--- a/src/g3log/logcapture.hpp
+++ b/src/g3log/logcapture.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "g3log/loglevels.hpp"
-#include "g3log/g3log.hpp"
 #include "g3log/crashhandler.hpp"
 
 #include <string>
@@ -41,8 +40,8 @@ struct LogCapture {
 
 
    // At destruction the message will be forwarded to the g3log worker.
-   // in case of dynamically (at runtime) loaded libraries the important thing to know is that
-   // all strings are copied so the original are not destroyed at the receiving end, only the copy
+   // In the case of dynamically (at runtime) loaded libraries, the important thing to know is that
+   // all strings are copied, so the original are not destroyed at the receiving end, only the copy
    virtual ~LogCapture();
 
 

--- a/src/logcapture.cpp
+++ b/src/logcapture.cpp
@@ -7,6 +7,7 @@
  * ============================================================================*/
 
 #include "g3log/logcapture.hpp"
+#include "g3log/g3log.hpp"
 #include "g3log/crashhandler.hpp"
 
 #ifdef G3_DYNAMIC_MAX_MESSAGE_SIZE
@@ -14,7 +15,7 @@
 #endif /* G3_DYNAMIC_MAX_MESSAGE_SIZE */
 
 // For Windows we need force a thread_local install per thread of three
-// signals that must have a signal handler instealled per thread-basis
+// signals that must have a signal handler installed per thread-basis
 // It is really a royal pain. Seriously Microsoft? Seriously?
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
 #define SIGNAL_HANDLER_VERIFY() g3::installSignalHandlerForThread()
@@ -97,7 +98,7 @@ void LogCapture::capturef(const char *printf_like_message, ...) {
    va_end(arglist);
 
    if (nbrcharacters <= 0) {
-      stream() << "\n\tERROR LOG MSG NOTIFICATION: Failure to parse successfully the message";
+      stream() << "\n\tERROR LOG MSG NOTIFICATION: Failure to successfully parse the message";
       stream() << '"' << printf_like_message << '"' << std::endl;
    } else if (nbrcharacters > finished_message_len) {
       stream() << finished_message << kTruncatedWarningText;


### PR DESCRIPTION
logcapture.hpp and g3log.hpp included each other.  Fixed by moving include to logcapture.cpp since logcapture.hpp didn't actually use any of it.  