### PR TITLE
cmake: Avoid extra recompilation updating generated_definitions.hpp only if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ nbproject/*
 build_clang
 build_travis
 gtest-1.7.0
-generated_definitions.hpp
 *~

--- a/GenerateMacroDefinitionsFile.cmake
+++ b/GenerateMacroDefinitionsFile.cmake
@@ -21,20 +21,33 @@
 message( STATUS "" )
 message( STATUS "COMPILE_DEFINITIONS:\n\t[${G3_DEFINITIONS}]" )
 message( STATUS "" )
+
 SET(GENERATED_G3_DEFINITIONS "${CMAKE_CURRENT_BINARY_DIR}/include/g3log/generated_definitions.hpp")
-file(REMOVE ${GENERATED_G3_DEFINITIONS} )
-FILE(WRITE ${GENERATED_G3_DEFINITIONS} "// AUTO GENERATED MACRO DEFINITIONS FOR G3LOG\n\n")
-FILE(APPEND ${GENERATED_G3_DEFINITIONS} "${HEADER}\n")
-FILE(APPEND ${GENERATED_G3_DEFINITIONS} "#pragma once\n\n")
-FILE(APPEND ${GENERATED_G3_DEFINITIONS} "// CMake induced definitions below. See g3log/Options.cmake for details.\n\n")
+
+# If it exists, read existing file
+set(current_content "")
+if(EXISTS ${GENERATED_G3_DEFINITIONS})
+  file(READ ${GENERATED_G3_DEFINITIONS} current_content)
+endif()
+
+set(generated_content "// AUTO GENERATED MACRO DEFINITIONS FOR G3LOG\n\n")
+set(generated_content "${generated_content}\n${HEADER}\n")
+set(generated_content "${generated_content}\n#pragma once\n\n")
+set(generated_content "${generated_content}\n// CMake induced definitions below. See g3log/Options.cmake for details.\n\n")
 
 FOREACH(definition ${G3_DEFINITIONS} )
-   FILE(APPEND ${GENERATED_G3_DEFINITIONS} "#define ${definition}\n")
+  set(generated_content "${generated_content}\n#define ${definition}\n")
 ENDFOREACH(definition)
 
-message( STATUS "Generated ${GENERATED_G3_DEFINITIONS}" )
-file(READ ${GENERATED_G3_DEFINITIONS} generated_content)
+if(NOT "${current_content}" STREQUAL "${generated_content}")
 
-message( STATUS "******************** START *************************" )
-MESSAGE(${generated_content})
-message( STATUS "******************** END *************************" )
+  message( STATUS "Generated ${GENERATED_G3_DEFINITIONS}" )
+
+  message( STATUS "******************** START *************************" )
+  message(${generated_content})
+  message( STATUS "******************** END *************************" )
+
+  file(WRITE ${GENERATED_G3_DEFINITIONS} ${generated_content})
+
+endif()
+


### PR DESCRIPTION
This commit updates the build system to ensure the generated_definitions
header is updated only if its content changed. This will avoid recompilation
if the re-configured without changing any options.