### PR TITLE
 CMake: CMAKE_INSTALL_PREFIX for Linux

### DIFF
--- a/CPackLists.txt
+++ b/CPackLists.txt
@@ -15,12 +15,10 @@
  #           DESTINATION include
  #           COMPONENT headers)
 
-IF(MINGW)
-   SET(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/g3log")
-ENDIF()
-
 IF(NOT MINGW)
-   IF(NOT CPACK_PACKAGING_INSTALL_PREFIX)
+   IF(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+      SET(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+   ELSEIF(NOT CPACK_PACKAGING_INSTALL_PREFIX)
       SET(CPACK_PACKAGING_INSTALL_PREFIX /usr/local)
    ENDIF()
 ENDIF()
@@ -82,8 +80,8 @@ message( STATUS "make package" )
 message( STATUS "\nOption to install using 'make install'" )
 message( STATUS "Installation locations: " )
 message( STATUS "====================" )
-message( STATUS "Headers: ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_HEADERDIR}" )
-message( STATUS "Library installation directory: ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" )
+message( STATUS "Headers: ${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_HEADERDIR}" )
+message( STATUS "Library installation directory: ${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" )
 
 message( STATUS "For more information please see g3log/CPackLists.txt\n\n" )
 IF(NOT MINGW)

--- a/README.markdown
+++ b/README.markdown
@@ -211,6 +211,14 @@ cd ../../
 mkdir build
 cd build
 ```
+## Configuring for installing on nix (OSX, Linux, MinGW)
+Default install prefix on Linux is `/usr/local`
+To change it please set  `CPACK_PACKAGING_INSTALL_PREFIX `
+
+```
+cmake -DCPACK_PACKAGING_INSTALL_PREFIX= ...
+```
+
 
 ## Building on Linux
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -227,6 +227,21 @@ make package
 sudo dpkg -i g3log-<version>-Linux.deb
 ```
 
+## Building on MinGW
+```
+cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+make 
+```
+## Installing on MinGW
+```
+make install
+```
+Alternative using NSIS
+```
+make package
+g3log-<version>-win32.exe
+```
+
 ## Building on Windows
 Please use the Visual Studio 12 (2013) command prompt "Developer command prompt"
 ```


### PR DESCRIPTION
Now CMAKE_INSTALL_PREFIX and CPACK_PACKAGING_INSTALL_PREFIX both work correctly on Linux, but if both defined during build CMAKE_INSTALL_PREFIX overrides CPACK value.

I also have updated README with MinGW building and installation.