### PR TITLE
API suggestion changes

### DIFF
--- a/src/g3log/shared_queue.hpp
+++ b/src/g3log/shared_queue.hpp
@@ -77,4 +77,9 @@ public:
       std::lock_guard<std::mutex> lock(m_);
       return queue_.size();
    }
+   
+   unsigned size_unsynchronized() const {
+      return queue_.size();
+   }
+   
 };


### PR DESCRIPTION
Since the shared_queue is used outside of g3log. 
It would be useful to improve the api for it for clients that want an upper limit of how much the queue can grow.  
```
   void try_push(T item,  size_t maxSize) {
      {
         std::lock_guard<std::mutex> lock(m_);
         if (size_unsynchronized() < maxSize) {
            queue_.push(std::move(item));
        } else {
           return false;
       }
      }
      data_cond_.notify_one();
      return true;
   }
```