### PR TITLE
restore original sigaction in restoreSignalHandler

### DIFF
--- a/scripts/runAllTests.sh
+++ b/scripts/runAllTests.sh
@@ -4,7 +4,8 @@ set -v
 #set -x
 
 
-test_execs=`find ./test_* -perm /u=x` 
+# test_execs=`find ./test_* -perm /u=x` 
+test_execs=`find ./test_* -type f -perm +ugo+x -print`
 
 echo "Tests to run: $test_execs"
 

--- a/src/crashhandler_unix.cpp
+++ b/src/crashhandler_unix.cpp
@@ -67,7 +67,7 @@ namespace {
       if (sigaction(signal_number, &(old_action_it->second), nullptr) < 0) {
          std::string signal_name;
          auto signal_name_it = gSignals.find(signal_number);
-         if (signal_name_it == gSignals.end()) {
+         if (signal_name_it != gSignals.end()) {
             signal_name = signal_name_it->second;
          } else {
             signal_name = std::to_string(signal_number);

--- a/src/g3log/crashhandler.hpp
+++ b/src/g3log/crashhandler.hpp
@@ -38,11 +38,17 @@ namespace g3 {
    void installSignalHandlerForThread();
 #else
    typedef int SignalType;
-
    /// Probably only needed for unit testing. Resets the signal handling back to default
    /// which might be needed in case it was previously overridden
    /// The default signals are: SIGABRT, SIGFPE, SIGILL, SIGSEGV, SIGTERM
    void restoreSignalHandlerToDefault();
+
+
+   std::string signalToStr(int signal_number);
+
+   // restore to whatever signal handler was used before signal handler installation 
+   void restoreSignalHandler(int signal_number);
+
 
    /// Overrides the existing signal handling for custom signals
    /// For example: usage of zcmq relies on its own signal handler for SIGTERM


### PR DESCRIPTION
- Save original sigactions in a map called gSavedSigActions
- In restoreSignalHandler, do nothing if there is no saved sigaction.
  If there is a saved sigaction, then re-install it.
- Fixes issue #253 
