### PR TITLE
Use defective stlpatch_future.hpp only for VS2013

### DIFF
--- a/src/g3log/stlpatch_future.hpp
+++ b/src/g3log/stlpatch_future.hpp
@@ -14,7 +14,7 @@
 
 
 #pragma once
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__)) && !defined(__MINGW32__)
+#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__)) && !defined(__MINGW32__) && (_MSC_VER <= 1800)
 namespace std {
 
    template<class... _ArgTypes>


### PR DESCRIPTION
The void return type specialization stlpatch_future.hpp does not store exceptions thrown in the callable. It is silently overwriting the Microsoft implementation in all VS versions in all implementation files pulling g3log headers.
This is the minimum fix: Starting with VS2015 the original implementation is used. 
