### PR TITLE
Improved readme for Windows 64 bit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,9 @@
 #    cd build;
 # 3. cmake -DCMAKE_BUILD_TYPE=Release -G "Visual Studio XXX" ..
 #     (cmake -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 12")
-#     MAKE SURE you check thr CMake documentation so you are using
-#     the correct bit flags also (64 bit etc). The "XXX" needs 
-#     to be replaced for your build system. 
+#     MAKE SURE you check the CMake documentation so you are using
+#     the correct bit flags(64 bit etc). The "XXX" needs 
+#     tto be replaced for your specific build system, ref: cmake docs.
 # 
 #     (Example from Appveyor Ci: 
 #      https://github.com/KjellKod/g3log/blob/master/appveyor.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,15 @@
 #    cd build;
 # 3. cmake -DCMAKE_BUILD_TYPE=Release -G "Visual Studio XXX" ..
 #     (cmake -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 12")
-#    (XXX is the Visual Studio version you are running)
-# 4. msbuild g3log.sln /p:Configuration=Release
+#     MAKE SURE you check thr CMake documentation so you are using
+#     the correct bit flags also (64 bit etc). The "XXX" needs 
+#     to be replaced for your build system. 
+# 
+#     (Example from Appveyor Ci: 
+#      https://github.com/KjellKod/g3log/blob/master/appveyor.yml
+#      cmake -G "Visual Studio 14 2015 Win64" -DADD_G3LOG_UNIT_TEST=ON ..)
+#
+#      4. msbuild g3log.sln /p:Configuration=Release
 #
 # Try to run an example, such as:
 # 5. Release\g3log-FATAL-contract.exe


### PR DESCRIPTION
This clarifies that Windows users have to check the CMake documentation

* Follow TDD practice. 
* All new and modified functionality should be backed up with unit tests. 
* All new functionality should be backed up with API documentation (API.markdown or README.markdown)
