### PR TITLE
Fix: VS 2015 logmessage.cpp(167): error C2437: "_file" already initialized

### DIFF
--- a/src/logmessage.cpp
+++ b/src/logmessage.cpp
@@ -157,9 +157,10 @@ namespace g3 {
       : _logDetailsToStringFunc(LogMessage::DefaultLogDetailsToString)
       , _timestamp(std::chrono::high_resolution_clock::now())
       , _call_thread_id(std::this_thread::get_id())
-      , _file(LogMessage::splitFileName(file))
 #if defined(G3_LOG_FULL_FILENAME)
       , _file(file)
+#else
+	   , _file(LogMessage::splitFileName(file))
 #endif
       , _file_path(file)
       , _line(line)


### PR DESCRIPTION
When trying to compile with VS2015 I receive the following error (german error text, english something like: "already initialized" [msdn C2437](https://msdn.microsoft.com/en-us/library/xhze21a2.aspx))
```
\g3log\src\logmessage.cpp(167): error C2437: "_file": Wurde bereits initialisiert.
```
