### PR TITLE
Use C++11 generic attribute syntax to avoid issue #282

### DIFF
--- a/src/g3log/logcapture.hpp
+++ b/src/g3log/logcapture.hpp
@@ -47,11 +47,6 @@ struct LogCapture {
 
 
 
-   // Use "-Wall" to generate warnings in case of illegal printf format.
-   //      Ref:  http://www.unixwiz.net/techtips/gnu-c-attributes.html
-#ifndef __GNUC__
-#define  __attribute__(x) // Disable 'attributes' if compiler does not support 'em
-#endif 
 #ifdef _MSC_VER 
 #	if _MSC_VER >= 1400
 #		define G3LOG_FORMAT_STRING _Printf_format_string_
@@ -61,7 +56,10 @@ struct LogCapture {
 #else
 #	define G3LOG_FORMAT_STRING
 #endif
-   void capturef(G3LOG_FORMAT_STRING const char *printf_like_message, ...) __attribute__((format(printf, 2, 3))); // 2,3 ref:  http://www.codemaestro.com/reviews/18
+
+   // Use "-Wall" to generate warnings in case of illegal printf format.
+   //      Ref:  http://www.unixwiz.net/techtips/gnu-c-attributes.html
+   [[gnu::format(printf, 2, 3)]] void capturef(G3LOG_FORMAT_STRING const char *printf_like_message, ...); // 2,3 ref:  http://www.codemaestro.com/reviews/18
 
 
    /// prettifying API for this completely open struct


### PR DESCRIPTION
This is meant to fix issue #282.

By using C++11 generic attribute syntax I think compiler specific preprocessor conditionals and macro definitions can be entirely avoided in this context.

With my locally available compilers I have confirmed that GCC still produces format violation diagnostics as expected and that Clang simulating cl no longer produces the errors I reported.

Microsoft cl expectedly ignores the unknown attribute.

I am not entirely sure if other compilers ignore the attribute when they don't know it.
It seems to be required since C++17[1] but that may suggest that some compilers may have behaved differently (implementation defined) before.

[1] http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0283r2.html