### PR TITLE
Wrap gnu::format around #if to avoid msvc warnings

### DIFF
--- a/src/g3log/logcapture.hpp
+++ b/src/g3log/logcapture.hpp
@@ -53,6 +53,8 @@ struct LogCapture {
 #	else
 #		define G3LOG_FORMAT_STRING __format_string
 #	endif
+   
+    void capturef(G3LOG_FORMAT_STRING const char *printf_like_message, ...);
 #else
 #	define G3LOG_FORMAT_STRING
 

--- a/src/g3log/logcapture.hpp
+++ b/src/g3log/logcapture.hpp
@@ -55,12 +55,11 @@ struct LogCapture {
 #	endif
 #else
 #	define G3LOG_FORMAT_STRING
-#endif
 
    // Use "-Wall" to generate warnings in case of illegal printf format.
    //      Ref:  http://www.unixwiz.net/techtips/gnu-c-attributes.html
    [[gnu::format(printf, 2, 3)]] void capturef(G3LOG_FORMAT_STRING const char *printf_like_message, ...); // 2,3 ref:  http://www.codemaestro.com/reviews/18
-
+#endif
 
    /// prettifying API for this completely open struct
    std::ostringstream &stream() {


### PR DESCRIPTION
Minor change to avoid warning issue by attribute gnu::format that was added with #283 
