### PR TITLE
add option G3_SHARED_RUNTIME

### DIFF
--- a/Build.cmake
+++ b/Build.cmake
@@ -116,8 +116,25 @@ ENDIF()
       ENDIF()
       ADD_LIBRARY(${G3LOG_LIBRARY} SHARED ${SRC_FILES})
    ELSE()
+      IF(MSVC)
+         IF(NOT G3_SHARED_RUNTIME)
+            SET(CompilerFlags
+                  CMAKE_CXX_FLAGS
+                  CMAKE_CXX_FLAGS_DEBUG
+                  CMAKE_CXX_FLAGS_RELEASE
+                  CMAKE_C_FLAGS
+                  CMAKE_C_FLAGS_DEBUG
+                  CMAKE_C_FLAGS_RELEASE
+               )
+            foreach(CompilerFlag ${CompilerFlags})
+               string(REPLACE "/MDd" "/MTd" ${CompilerFlag} "${${CompilerFlag}}")
+               string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+            endforeach()
+         ENDIF()
+      ENDIF()
       ADD_LIBRARY(${G3LOG_LIBRARY} STATIC ${SRC_FILES})
    ENDIF()
+
 
    SET(${G3LOG_LIBRARY}_VERSION_STRING ${VERSION})
    MESSAGE( STATUS "Creating ${G3LOG_LIBRARY} VERSION: ${VERSION}" )

--- a/Options.cmake
+++ b/Options.cmake
@@ -105,6 +105,14 @@ ELSE()
    MESSAGE( STATUS "-DG3_SHARED_LIB=OFF\tBuild static library")  
 ENDIF()
 
+# Option for building as a static or shared runtime library in MS VC++
+option (G3_SHARED_RUNTIME  "Build shared runtime library MS VC" ON)
+IF(G3_SHARED_RUNTIME)
+   message( STATUS "-DG3_SHARED_RUNTIME=ON\tBuild shared runtime library" )
+ELSE()
+   message( STATUS "-DG3_SHARED_RUNTIME=OFF\tBuild static runtime library")
+ENDIF()
+
 # WINDOWS OPTIONS
 IF (MSVC OR MINGW) 
 # -DENABLE_VECTORED_EXCEPTIONHANDLING=ON   : defualt change the


### PR DESCRIPTION
add option G3_SHARED_RUNTIME for building as a static or shared runtime library in MS VC++
