### PR TITLE
Mingw parse error

### DIFF
--- a/src/crashhandler_unix.cpp
+++ b/src/crashhandler_unix.cpp
@@ -11,7 +11,7 @@
 #include "g3log/logcapture.hpp"
 #include "g3log/loglevels.hpp"
 
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__) && !defined(__GNUC__))
+#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
 #error "crashhandler_unix.cpp used but it's a windows system"
 #endif
 

--- a/src/logcapture.cpp
+++ b/src/logcapture.cpp
@@ -80,7 +80,7 @@ void LogCapture::capturef(const char *printf_like_message, ...) {
 #else
    static const int kMaxMessageSize = 2048;
    char finished_message[kMaxMessageSize];
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__) && !defined(__GNUC__))
+#if ((defined(WIN32) || defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__))
    auto finished_message_len = _countof(finished_message);
 #else
    int finished_message_len = sizeof(finished_message);
@@ -90,7 +90,7 @@ void LogCapture::capturef(const char *printf_like_message, ...) {
    va_list arglist;
    va_start(arglist, printf_like_message);
 
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__) && !defined(__GNUC__))
+#if ((defined(WIN32) || defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__))
    const int nbrcharacters = vsnprintf_s(finished_message, finished_message_len, _TRUNCATE, printf_like_message, arglist);
 #else
    const int nbrcharacters = vsnprintf(finished_message, finished_message_len, printf_like_message, arglist);

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -131,7 +131,7 @@ namespace g3 {
 
    tm localtime(const std::time_t& ts) {
       struct tm tm_snapshot;
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__) && !defined(__GNUC__))
+#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
       localtime_s(&tm_snapshot, &ts); // windsows
 #else
       localtime_r(&ts, &tm_snapshot); // POSIX


### PR DESCRIPTION
after build on mingw  this code 
`LOGF(G3LOG_DEBUG, "[BaseEditor] newFirstLine=%zd, parseFrom=%d, parseTo=%d", firstLine, parseFrom, parseTo);`
write in log 
`ERROR LOG MSG NOTIFICATION: Failure to successfully parse the message"[BaseEditor] newFirstLine=%zd, parseFrom=%d, parseTo=%d"`

1. fixed the order of logic operations
2. removed extra checks. This functionality will not work on windows with/without gcc