### PR TITLE
Create an IMPORT target in g3loggerConfig.cmake

### DIFF
--- a/cmake/g3loggerConfig.cmake
+++ b/cmake/g3loggerConfig.cmake
@@ -4,23 +4,20 @@
 #
 # Find libg3logger, G3log is an asynchronous, "crash safe", logger that is easy to use with default logging sinks or you can add your own.
 #
-# Result variables
-# ^^^^^^^^^^^^^^^^
-#
-# This module will set the following variables in your project:
-#
-# ``G3LOG_INCLUDE_DIRS``
-#   where to find g3log.hpp, etc.
-#
-# ``G3LOG_LIBRARIES``
-#   the libraries to link against to use libg3logger.
-#
-#   that includes libg3logger library files.
-# ``G3LOG_FOUND``
-#
-#   If false, do not try to use G3LOG.
+# This defines the cmake import target "g3logger" you can use like this
+#```
+# target_link_libraries(YourTarget PUBLIC g3logger)
+#```
+# Variables and features 
+# ----------------------
+# * ``G3LOG`` -- if this environment variable is set, it'll be used as a hint as to where the g3logger files are. 
+# * ``G3LOG_INCLUDE_DIRS`` -- raw cmake variable with include path 
+# * ``G3LOG_LIBRARIES`` -- raw cmake variable with library link line
+# * ``G3LOG_FOUND`` -- check if the lib was found without using the newer ``if(TARGET g3logger)...``
+
 include(FindPackageHandleStandardArgs)
 find_path(G3LOG_INCLUDE_DIR 
+    NAMES
          g3log/active.hpp
          g3log/atomicbool.hpp
          g3log/crashhandler.hpp
@@ -40,14 +37,21 @@ find_path(G3LOG_INCLUDE_DIR
          g3log/stacktrace_windows.hpp
          g3log/stlpatch_future.hpp
          g3log/time.hpp
+    PATHS        
+        ENV G3LOG
 )
-
 find_library(G3LOG_LIBRARY
-            NAMES libg3logger g3logger)
-
-find_package_handle_standard_args(G3LOG  DEFAULT_MSG
-            G3LOG_INCLUDE_DIR G3LOG_LIBRARY)
-
+            NAMES libg3logger g3logger )
+find_package_handle_standard_args(g3logger
+            REQUIRED_VARS G3LOG_INCLUDE_DIR G3LOG_LIBRARY)
 mark_as_advanced(G3LOG_INCLUDE_DIR G3LOG_LIBRARY)
 set(G3LOG_LIBRARIES ${G3LOG_LIBRARY})
 set(G3LOG_INCLUDE_DIRS ${G3LOG_INCLUDE_DIR})
+
+add_library(g3logger SHARED IMPORTED)
+find_package(Threads REQUIRED)
+set_target_properties(g3logger PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${G3LOG_INCLUDE_DIRS}"
+    IMPORTED_LOCATION "${G3LOG_LIBRARY}"
+    IMPORTED_LINK_INTERFACE_LIBRARIES Threads::Threads
+    )


### PR DESCRIPTION
This adds two features to the g3loggerConfig.cmake that gets installed:

1. The environment variable G3LOG  can be used to find the logger files in different locations.

2. The import target `g3logger` is defined.

If downstream is required to compile for std cxx11 or later, this will have to be altered to add that to the target.
