### PR TITLE
Updated CMakeLists.txt to enable installing on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,13 @@ IF(MINGW)
    ADD_DEFINITIONS(-DMINGW_HAS_SECURE_API)
 ENDIF()
 
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+   # ==========================================================================
+   #        Tested with Windows 10 and Visual Studio 2017
+   # ==========================================================================
+   INCLUDE (${g3log_SOURCE_DIR}/CPackLists.txt)
+ENDIF()
+
 IF (NOT MSVC)
    message( STATUS "\n\n
       *******************************************************************


### PR DESCRIPTION
OK, Kjell, I made a small modification to enable g3logger to be installed on windows.  In order to avoid requiring it to be run as administrator, I used the following command to build.

cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=c:/usr/local -DCMAKE_INSTALL_PREFIX=c:/usr/local ..

I didn't pass in a specific generator but let it select the currently installed Visual Studio.

I followed up with this command to build and install

cmake --build . --target INSTALL --config Debug

This successfully installed g3log under c:/usr/local.  I used Debug on both of these to enable debugging from the Visual Studio IDE as I was developing.  Obviously these could be replaced with Release for a Release build.

I recognize that I should create some tests and I'll be reading up on ctest, gtest and CI so I can get there but it may take a bit.  I didn't make any updates to the README or API.markdown but I'll do that as well as I get tests set up.

I felt like I needed to do this to enable and guide the work I'm doing on g3sink/tracelogging, which I also have a cut of to submit momentarily but based on where this is currently, I'll understand if you reject the pull.  If you accept or not, any suggestions on how to set up tests on Windows and how to set up Windows CI will be appreciated.

Jeff