### PR TITLE
Set link to local files as relative

### DIFF
--- a/API.markdown
+++ b/API.markdown
@@ -168,7 +168,7 @@ Example code for replacing the default log formatting for "full details" formatt
    handle->call(&g3::FileSink::overrideLogDetails, &LogMessage::FullLogDetailsToString);
 ```
 
-See [test_message.cpp](http://www.github.com/KjellKod/g3log/test_unit/test_message.cpp) for details and testing
+See [test_message.cpp](test_unit/test_message.cpp) for details and testing
 
 
 Example code for overloading the formatting of a custom sink. The log formatting function will be passed into the 
@@ -324,7 +324,7 @@ The default behaviour for G3log is to catch several fatal events before they for
    ```
    
    ### <a name="fatal_handling_disabled">Disable fatal handling</a>
-   Fatal signal handling can be disabled with a CMake option: `ENABLE_FATAL_SIGNALHANDLING`. See [Options.cmake](https://github.com/KjellKod/g3log/blob/master/Options.cmake) for more details
+   Fatal signal handling can be disabled with a CMake option: `ENABLE_FATAL_SIGNALHANDLING`. See [Options.cmake](Options.cmake) for more details
 
 
    ### <a name="PID1">PID1 Fatal Signal Recommendations</a>


### PR DESCRIPTION
The link to the file test_message.cpp was broken. I fixed it with a relative path as it is easier when working on forks. I also changed the link to Options.qmake for the same reason (the initial link wasn't broken thought).