### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -399,7 +399,7 @@ By default, tests will not be built. To enable unit testing, you should turn on 
 
 Suppose the build process has completed, then you can run the tests with:
 ```
-ctest . -C Release
+ctest -C Release
 ```
 or:
 ```
@@ -439,7 +439,7 @@ Most of the API that you need for using g3log is described in this readme. For m
 * CHECK calls
 
 
-#Performance
+# Performance
 G3log aims to keep all background logging to sinks with as little log overhead as possible to the logging sink and with as small "worst case latency" as possible. For this reason g3log is a good logger for many systems that deal with critical tasks. Depending on platform the average logging overhead will differ. On my laptop the average call, when doing extreme performance testing, will be about ~2 us.
 
 The worst case latency is kept stabile with no extreme peaks, in spite of any sudden extreme pressure.  I have a blog post regarding comparing worst case latency for g3log and other loggers which might be of interest. 


### PR DESCRIPTION
- There is no need to specify the build directory when running `ctest`.
- Fix `Performance` section rendering.