### PR TITLE
fix issue with stacktrace_windows not allocating sufficient memory fo…

### DIFF
--- a/src/stacktrace_windows.cpp
+++ b/src/stacktrace_windows.cpp
@@ -110,7 +110,7 @@ namespace {
 
       DWORD64 displacement64;
       DWORD displacement;
-      char symbol_buffer[sizeof(SYMBOL_INFO) + 256];
+      char symbol_buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME];
       SYMBOL_INFO *symbol = reinterpret_cast<SYMBOL_INFO *>(symbol_buffer);
       symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
       symbol->MaxNameLen = MAX_SYM_NAME;
@@ -120,7 +120,7 @@ namespace {
       std::string lineInformation;
       std::string callInformation;
       if (SymFromAddr(GetCurrentProcess(), addr, &displacement64, symbol)) {
-         callInformation.append(" ").append({std::string(symbol->Name), symbol->NameLen});
+         callInformation.append(" ").append(std::string(symbol->Name, symbol->NameLen));
          if (SymGetLineFromAddr64(GetCurrentProcess(), addr, &displacement, &line)) {
             lineInformation.append("\t").append(line.FileName).append(" L: ");
             lineInformation.append(std::to_string(line.LineNumber));


### PR DESCRIPTION
…r SYMBOL_INFO struct

We encountered an issue in a private code base where printing out the stack after an error would itself cause an access violation in debug builds on Windows. The issue ends up being that the SYMBOL_INFO struct was constructed with insufficient memory to store the symbol name, which far exceeded the allocated amount of memory.

The issue is resolved by allocating more stack memory to allow for the use of up to MAX_SYM_NAME characters in the name field.