### PR TITLE
remove std::move in return : std::future can only be moved anyway

### DIFF
--- a/src/g3log/future.hpp
+++ b/src/g3log/future.hpp
@@ -58,6 +58,6 @@ namespace g3 {
 
       std::future<result_type> result = task.get_future();
       worker->send(MoveOnCopy<task_type>(std::move(task)));
-      return std::move(result);
+      return result;
    }
 } // end namespace g3


### PR DESCRIPTION
Removes a compiler warning in future.hpp. 
http://www.cplusplus.com/reference/future/future/future/
std::future<> can only be moved, its copy constructor is deleted, so return will move "result" anyway.