### PR TITLE
Allow throwing from exit handler

### DIFF
--- a/src/g3log/logcapture.hpp
+++ b/src/g3log/logcapture.hpp
@@ -42,7 +42,7 @@ struct LogCapture {
    // At destruction the message will be forwarded to the g3log worker.
    // In the case of dynamically (at runtime) loaded libraries, the important thing to know is that
    // all strings are copied, so the original are not destroyed at the receiving end, only the copy
-   virtual ~LogCapture();
+   virtual ~LogCapture() noexcept (false);
 
 
 

--- a/src/logcapture.cpp
+++ b/src/logcapture.cpp
@@ -38,7 +38,7 @@ void g3::only_change_at_initialization::setMaxMessageSize(size_t max_size) {
 * As a safety precaution: No memory allocated here will be moved into the background
 * worker in case of dynamic loaded library reasons instead the arguments are copied
 * inside of g3log.cpp::saveMessage*/
-LogCapture::~LogCapture() {
+LogCapture::~LogCapture() noexcept (false) {
    using namespace g3::internal;
    SIGNAL_HANDLER_VERIFY();
    saveMessage(_stream.str().c_str(), _file, _line, _function, _level, _expression, _fatal_signal, _stack_trace.c_str());

--- a/test_unit/test_io.cpp
+++ b/test_unit/test_io.cpp
@@ -601,7 +601,34 @@ TEST(CHECK, CHECK_ThatWontThrow) {
    EXPECT_FALSE(verifyContent(mockFatalMessage(), msg3));
 }
 
+TEST(CHECK, CHECK_runtimeError) {
+   RestoreFileLogger logger(log_directory);
 
+   g3::setFatalExitHandler([](g3::FatalMessagePtr msg) {
+     throw std::runtime_error("fatal test handler");
+   });
+
+   class dynamic_int_array {
+     std::unique_ptr<int[]> data_;
+     const int size_;
+   public:
+     explicit dynamic_int_array(int size)
+         : data_{std::make_unique<int[]>(size)}
+         , size_(size)
+    {}
+
+    int& at(int i) {
+      CHECK(i < size_);
+
+      // unreachable if i >= size_
+      return data_[i];
+    }
+   };
+
+   dynamic_int_array arr{3};
+
+   EXPECT_THROW(arr.at(3) = 1, std::runtime_error);
+}
 
 TEST(CustomLogLevels, AddANonFatal) {
    RestoreFileLogger logger(log_directory);


### PR DESCRIPTION
For example for unit testing purposes we may want to replace SIGABRT with
throwing an exception, so that unit tests for CHECK()s can be written.

Solves #343 