### PR TITLE
Add atomic library for ARM processors

### DIFF
--- a/Build.cmake
+++ b/Build.cmake
@@ -125,6 +125,18 @@ target_compile_options(${G3LOG_LIBRARY} PRIVATE
    $<$<CXX_COMPILER_ID:GNU>:-rdynamic>
 )
 
+# Add atomic library for ARM processors
+IF(UNIX)
+  STRING(FIND ${CMAKE_SYSTEM_PROCESSOR} "arm" arm_res)
+  IF(${arm_res} EQUAL -1)
+    TARGET_LINK_LIBRARIES(${G3LOG_LIBRARY} atomic)
+  ENDIF()
+  STRING(FIND ${CMAKE_SYSTEM_PROCESSOR} "aarch" arm_res)
+  IF(${arm_res} EQUAL -1)
+    TARGET_LINK_LIBRARIES(${G3LOG_LIBRARY} atomic)
+  ENDIF()
+ENDIF()
+
 #cmake -DCMAKE_CXX_COMPILER=clang++ ..
   # WARNING: If Clang for Linux does not work with full c++14 support it might be your
   # installation that is faulty. When I tested Clang on Ubuntu I followed the following


### PR DESCRIPTION
On my ARM CPU (armv7l, but armel), the compilation hangs on this:
```
[ 60%] Linking CXX shared library libg3logger.so
[ 60%] Built target g3logger
Scanning dependencies of target g3log-FATAL-contract
[ 66%] Building CXX object CMakeFiles/g3log-FATAL-contract.dir/example/main_contract.cpp.o
[ 73%] Linking CXX executable g3log-FATAL-contract
/usr/bin/ld: libg3logger.so.1.3.2-94: undefined reference to `__atomic_fetch_add_8'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/g3log-FATAL-contract.dir/build.make:85: g3log-FATAL-contract] Error 1
make[1]: *** [CMakeFiles/Makefile2:73: CMakeFiles/g3log-FATAL-contract.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```
I find out that the atomic library is required to be linked on ARM processors, and now it compiles fine.
This patch works, although, I'm not much satisfied with ARM detection, sadly, I didn't found any better solution for this. Any improvements are welcomed.

Thanks

EDIT: Also the CI test on macOS failing, kinda not sure how is that possible ☹️ 