### PR TITLE
C++17:  sym link to latest log

### DIFF
--- a/src/filesink.cpp
+++ b/src/filesink.cpp
@@ -10,9 +10,8 @@
 #include "filesinkhelper.ipp"
 #include <cassert>
 #include <chrono>
-#if __cplusplus > 201402L
 #include <filesystem>
-#endif
+
 namespace g3 {
    using namespace internal;
 
@@ -32,26 +31,26 @@ namespace g3 {
 
       std::string file_name = createLogFileName(_log_prefix_backup, logger_id);
       _log_file_with_path = pathSanityFix(_log_file_with_path, file_name);
-      #if __cplusplus > 201402L
-         namespace fs = std::filesystem;
-         fs::path sym_path = fs::path(
-             _log_file_with_path.substr(0, _log_file_with_path.size() - 20) +
+ 
+      namespace fs = std::filesystem;
+      fs::path sym_path = fs::path(
+      _log_file_with_path.substr(0, _log_file_with_path.size() - 20) +
              ".log");
-         if (fs::exists(sym_path)){
-           fs::remove(sym_path);
-         }
-         fs::create_symlink(fs::path(_log_file_with_path), sym_path);
-      #endif
-         _outptr = createLogFile(_log_file_with_path);
+      if (fs::exists(sym_path)){
+        fs::remove(sym_path);
+      }
+      fs::create_symlink(fs::path(_log_file_with_path), sym_path);
 
-         if (!_outptr) {
-           std::cerr << "Cannot write log file to location, attempting current "
-                        "directory"
-                     << std::endl;
-           _log_file_with_path = "./" + file_name;
-           _outptr = createLogFile(_log_file_with_path);
-         }
-         assert(_outptr && "cannot open log file at startup");
+      _outptr = createLogFile(_log_file_with_path);
+
+      if (!_outptr) {
+        std::cerr << "Cannot write log file to location, attempting current "
+                     "directory"
+                  << std::endl;
+        _log_file_with_path = "./" + file_name;
+        _outptr = createLogFile(_log_file_with_path);
+      }
+      assert(_outptr && "cannot open log file at startup");
       
    }
 


### PR DESCRIPTION
I find it handy that glog creates symlink to latest log file. This patch requires c++17. So it may not be ok to merge but I think it might help people needing this feature searching in PRs.