### PR TITLE
bug fix: vsnprintf_s return value 0 isn't error

### DIFF
--- a/src/logcapture.cpp
+++ b/src/logcapture.cpp
@@ -97,7 +97,7 @@ void LogCapture::capturef(const char *printf_like_message, ...) {
 #endif
    va_end(arglist);
 
-   if (nbrcharacters <= 0) {
+   if (nbrcharacters < 0) {
       stream() << "\n\tERROR LOG MSG NOTIFICATION: Failure to successfully parse the message";
       stream() << '"' << printf_like_message << '"' << std::endl;
    } else if (nbrcharacters > finished_message_len) {


### PR DESCRIPTION
it is perfectly legal for a user to write
```cpp
std::string s = "";
LOGF(INFO, "%s", s.c_str());
```
however, because vsnprintf_s returns 0, g3log thinks error happens, which in fact is a false alarm.

Man page of  vsnprintf_s reads:
>>If an output error is encountered, a negative value is returned.

So return value of 0 shouldn't be regarded as an error.


