### PR TITLE
Fix compiler warnings and condition check improvements

### DIFF
--- a/src/crashhandler_unix.cpp
+++ b/src/crashhandler_unix.cpp
@@ -59,7 +59,7 @@ namespace {
    // Dump of stack,. then exit through g3log background worker
    // ALL thanks to this thread at StackOverflow. Pretty much borrowed from:
    // Ref: http://stackoverflow.com/questions/77005/how-to-generate-a-stacktrace-when-my-gcc-c-app-crashes
-   void signalHandler(int signal_number, siginfo_t* info, void* unused_context) {
+   void signalHandler(int signal_number, siginfo_t* /*info*/, void* /*unused_context*/) {
 
       // Only one signal will be allowed past this point
       if (false == shouldDoExit()) {

--- a/src/g3log/g3log.hpp
+++ b/src/g3log/g3log.hpp
@@ -150,12 +150,12 @@ namespace g3 {
 
 // 'Conditional' stream log
 #define LOG_IF(level, boolean_expression)  \
-   if (!g3::logLevel(level) || (boolean_expression) == false) {} else INTERNAL_LOG_MESSAGE(level).stream()
+   if (!g3::logLevel(level) || false == (boolean_expression)) {} else INTERNAL_LOG_MESSAGE(level).stream()
 
 // 'Design By Contract' stream API. Broken Contracts will exit the application by using fatal signal SIGABRT
 //  For unit testing, you can override the fatal handling using setFatalExitHandler(...). See tes_io.cpp for examples
 #define CHECK(boolean_expression)        \
-   if ((boolean_expression) == true) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).stream()
+   if (true == (boolean_expression)) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).stream()
 
 
 /** For details please see this
@@ -211,17 +211,17 @@ And here is possible output
 
 // Conditional log printf syntax
 #define LOGF_IF(level,boolean_expression, printf_like_message, ...) \
-   if (!g3::logLevel(level) || (boolean_expression) == false) {} else INTERNAL_LOG_MESSAGE(level).capturef(printf_like_message, ##__VA_ARGS__)
+   if (!g3::logLevel(level) || false == (boolean_expression)) {} else INTERNAL_LOG_MESSAGE(level).capturef(printf_like_message, ##__VA_ARGS__)
 
 // Design By Contract, printf-like API syntax with variadic input parameters.
 // Calls the signal handler if the contract failed with the default exit for a failed contract. This is typically SIGABRT
 // See g3log, setFatalExitHandler(...) which can be overriden for unit tests (ref test_io.cpp)
 #define CHECKF(boolean_expression, printf_like_message, ...)    \
-   if ((boolean_expression) == true) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).capturef(printf_like_message, ##__VA_ARGS__)
+   if (true == (boolean_expression)) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).capturef(printf_like_message, ##__VA_ARGS__)
 
 // Backwards compatible. The same as CHECKF.
 // Design By Contract, printf-like API syntax with variadic input parameters.
 // Calls the signal handler if the contract failed. See g3log, setFatalExitHandler(...) which can be overriden for unit tests
 // (ref test_io.cpp)
 #define CHECK_F(boolean_expression, printf_like_message, ...)    \
-   if ((boolean_expression) == true) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).capturef(printf_like_message, ##__VA_ARGS__)
+   if (true == (boolean_expression)) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).capturef(printf_like_message, ##__VA_ARGS__)

--- a/src/g3log/g3log.hpp
+++ b/src/g3log/g3log.hpp
@@ -145,17 +145,17 @@ namespace g3 {
 
 
 // LOG(level) is the API for the stream log
-#define LOG(level) if(!g3::logLevel(level)) {} else INTERNAL_LOG_MESSAGE(level).stream()
+#define LOG(level) if (!g3::logLevel(level)) {} else INTERNAL_LOG_MESSAGE(level).stream()
 
 
 // 'Conditional' stream log
 #define LOG_IF(level, boolean_expression)  \
-   if (false == (boolean_expression) || !g3::logLevel(level)) {} else INTERNAL_LOG_MESSAGE(level).stream()
+   if (!g3::logLevel(level) || !(boolean_expression)) {} else INTERNAL_LOG_MESSAGE(level).stream()
 
 // 'Design By Contract' stream API. Broken Contracts will exit the application by using fatal signal SIGABRT
 //  For unit testing, you can override the fatal handling using setFatalExitHandler(...). See tes_io.cpp for examples
 #define CHECK(boolean_expression)        \
-   if (true == (boolean_expression)) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).stream()
+   if (boolean_expression) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).stream()
 
 
 /** For details please see this
@@ -211,17 +211,17 @@ And here is possible output
 
 // Conditional log printf syntax
 #define LOGF_IF(level,boolean_expression, printf_like_message, ...) \
-   if (false == (boolean_expression) || !g3::logLevel(level)) {} else INTERNAL_LOG_MESSAGE(level).capturef(printf_like_message, ##__VA_ARGS__)
+   if (!g3::logLevel(level) || !(boolean_expression)) {} else INTERNAL_LOG_MESSAGE(level).capturef(printf_like_message, ##__VA_ARGS__)
 
 // Design By Contract, printf-like API syntax with variadic input parameters.
 // Calls the signal handler if the contract failed with the default exit for a failed contract. This is typically SIGABRT
 // See g3log, setFatalExitHandler(...) which can be overriden for unit tests (ref test_io.cpp)
 #define CHECKF(boolean_expression, printf_like_message, ...)    \
-   if (true == (boolean_expression)) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).capturef(printf_like_message, ##__VA_ARGS__)
+   if (boolean_expression) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).capturef(printf_like_message, ##__VA_ARGS__)
 
 // Backwards compatible. The same as CHECKF.
 // Design By Contract, printf-like API syntax with variadic input parameters.
 // Calls the signal handler if the contract failed. See g3log, setFatalExitHandler(...) which can be overriden for unit tests
 // (ref test_io.cpp)
 #define CHECK_F(boolean_expression, printf_like_message, ...)    \
-   if (true == (boolean_expression)) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).capturef(printf_like_message, ##__VA_ARGS__)
+   if (boolean_expression) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).capturef(printf_like_message, ##__VA_ARGS__)

--- a/src/g3log/g3log.hpp
+++ b/src/g3log/g3log.hpp
@@ -150,12 +150,12 @@ namespace g3 {
 
 // 'Conditional' stream log
 #define LOG_IF(level, boolean_expression)  \
-   if (!g3::logLevel(level) || !(boolean_expression)) {} else INTERNAL_LOG_MESSAGE(level).stream()
+   if (!g3::logLevel(level) || (boolean_expression) == false) {} else INTERNAL_LOG_MESSAGE(level).stream()
 
 // 'Design By Contract' stream API. Broken Contracts will exit the application by using fatal signal SIGABRT
 //  For unit testing, you can override the fatal handling using setFatalExitHandler(...). See tes_io.cpp for examples
 #define CHECK(boolean_expression)        \
-   if (boolean_expression) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).stream()
+   if ((boolean_expression) == true) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).stream()
 
 
 /** For details please see this
@@ -211,17 +211,17 @@ And here is possible output
 
 // Conditional log printf syntax
 #define LOGF_IF(level,boolean_expression, printf_like_message, ...) \
-   if (!g3::logLevel(level) || !(boolean_expression)) {} else INTERNAL_LOG_MESSAGE(level).capturef(printf_like_message, ##__VA_ARGS__)
+   if (!g3::logLevel(level) || (boolean_expression) == false) {} else INTERNAL_LOG_MESSAGE(level).capturef(printf_like_message, ##__VA_ARGS__)
 
 // Design By Contract, printf-like API syntax with variadic input parameters.
 // Calls the signal handler if the contract failed with the default exit for a failed contract. This is typically SIGABRT
 // See g3log, setFatalExitHandler(...) which can be overriden for unit tests (ref test_io.cpp)
 #define CHECKF(boolean_expression, printf_like_message, ...)    \
-   if (boolean_expression) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).capturef(printf_like_message, ##__VA_ARGS__)
+   if ((boolean_expression) == true) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).capturef(printf_like_message, ##__VA_ARGS__)
 
 // Backwards compatible. The same as CHECKF.
 // Design By Contract, printf-like API syntax with variadic input parameters.
 // Calls the signal handler if the contract failed. See g3log, setFatalExitHandler(...) which can be overriden for unit tests
 // (ref test_io.cpp)
 #define CHECK_F(boolean_expression, printf_like_message, ...)    \
-   if (boolean_expression) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).capturef(printf_like_message, ##__VA_ARGS__)
+   if ((boolean_expression) == true) {} else INTERNAL_CONTRACT_MESSAGE(#boolean_expression).capturef(printf_like_message, ##__VA_ARGS__)

--- a/src/loglevels.cpp
+++ b/src/loglevels.cpp
@@ -132,7 +132,8 @@ namespace g3 {
       int level = log_level.value;
       bool status = internal::g_log_levels[level].status.value();
       return status;
-#endif
+#else
       return true;
+#endif
    }
 } // g3


### PR DESCRIPTION
- [ ] **TDD** 

New/modified code must be backed down with unit test - preferably TDD style development)


- [ ] **Documentation**

All new/modified functionality should be backed up with API documentation (API.markdown or README.markdown)


**Cross-Platform Testing**
- [ ] Travis-CI (Linux, OSX) + AppVeyor-CI (Windows)\
- [x] *Optional:* Local/VM testing: Windows
- [x] *Optional:* Local/VM testing: OSX
- [x] *Optional:* Local/VM testing: Linux


**Testing Advice**
```bash 
mkdir build; cd build; cmake -DADD_G3LOG_UNIT_TEST=ON ..
```

**Run Test Alternatives:** 
- Cross-Platform: `ctest`
- or `ctest -V` for verbose output
- Linux: `make test`

----

### Fix compiler warnings

- loglevels.cpp - warns about double return if dynamic logging is on
- crashhandler_unix.cpp - warns about unused variable

### Condition check improvements

1. ~Make the condition check more "C++ intuitive"~ (reverted)

For example, people may do something like below:
```cpp
// log the value if pointer is not null
LOG_IF(DEBUG, ptr) << "value: " << ptr->val;
```
This would not work since `ptr != true`, and would possibly confuse them

2. Checking if log level is enabled first.
If it's disabled, there's no need to evaluate the expression (which can be expensive)
