### PR TITLE
Avoid copying LOGLEVELS for g3::logLevel call

### DIFF
--- a/src/g3log/loglevels.hpp
+++ b/src/g3log/loglevels.hpp
@@ -187,6 +187,6 @@ namespace g3 {
 
 #endif
    /// Enabled status for the given logging level
-   bool logLevel(LEVELS level);
+   bool logLevel(const LEVELS& level);
 
 } // g3

--- a/src/loglevels.cpp
+++ b/src/loglevels.cpp
@@ -127,7 +127,7 @@ namespace g3 {
 #endif
 
 
-   bool logLevel(LEVELS log_level) {
+   bool logLevel(const LEVELS& log_level) {
 #ifdef G3_DYNAMIC_LOGGING
       int level = log_level.value;
       bool status = internal::g_log_levels[level].status.value();


### PR DESCRIPTION
Don't require copy-constructing a LOGLEVELS instance in order to call g3::logLevel.

This saves an allocation every log statement including when logging is disabled.