### PR TITLE
Fix pretty function magic constant overwriting

### DIFF
--- a/src/g3log/g3log.hpp
+++ b/src/g3log/g3log.hpp
@@ -30,8 +30,12 @@
 #include <functional>
 
 
-#if !(defined(__PRETTY_FUNCTION__))
-#define __PRETTY_FUNCTION__   __FUNCTION__
+#if defined(__GNUC__)   // GCC extension compatible
+#define G3LOG_PRETTY_FUNCTION __PRETTY_FUNCTION__
+#elif defined(_MSC_VER) // Microsoft
+#define G3LOG_PRETTY_FUNCTION __FUNCSIG__
+#else                   // Fallback to c99 / c++11
+#define G3LOG_PRETTY_FUNCTION __func__
 #endif
 
 // thread_local doesn't exist before VS2013
@@ -138,10 +142,10 @@ namespace g3 {
    } // internal
 } // g3
 
-#define INTERNAL_LOG_MESSAGE(level) LogCapture(__FILE__, __LINE__, static_cast<const char*>(__PRETTY_FUNCTION__), level)
+#define INTERNAL_LOG_MESSAGE(level) LogCapture(__FILE__, __LINE__, static_cast<const char*>(G3LOG_PRETTY_FUNCTION), level)
 
 #define INTERNAL_CONTRACT_MESSAGE(boolean_expression)  \
-   LogCapture(__FILE__, __LINE__, __PRETTY_FUNCTION__, g3::internal::CONTRACT, boolean_expression)
+   LogCapture(__FILE__, __LINE__, G3LOG_PRETTY_FUNCTION, g3::internal::CONTRACT, boolean_expression)
 
 
 // LOG(level) is the API for the stream log

--- a/test_unit/test_io.cpp
+++ b/test_unit/test_io.cpp
@@ -640,7 +640,7 @@ TEST(CustomLogLevels, AddANonFatal) {
    logger.reset();
    std::string file_content = readFileToText(logger.logFile());
    std::string expected;
-   expected += "MY_INFO_LEVEL [test_io.cpp->" + std::string(__FUNCTION__) + ":" + std::to_string(line);
+   expected += "MY_INFO_LEVEL [test_io.cpp->" + std::string(G3LOG_PRETTY_FUNCTION) + ":" + std::to_string(line);
    EXPECT_TRUE(verifyContent(file_content, expected)) << file_content
          << "\n\nExpected: \n" << expected;
 }
@@ -663,7 +663,7 @@ TEST(CustomLogLevels, AddFatal) {
 
    std::string file_content = readFileToText(logger.logFile());
    std::string expected;
-   expected += "DEADLY [test_io.cpp->" + std::string(__FUNCTION__) + ":" + std::to_string(line);
+   expected += "DEADLY [test_io.cpp->" + std::string(G3LOG_PRETTY_FUNCTION) + ":" + std::to_string(line);
    EXPECT_TRUE(verifyContent(file_content, expected)) << file_content
          << "\n\nExpected: \n" << expected;
    g_fatal_counter.store(0); // restore
@@ -734,7 +734,7 @@ TEST(CustomLogLevels, AddANonFatal__DidtAddItToEnabledValue) {
    logger.reset();
    std::string file_content = readFileToText(logger.logFile());
    std::string expected;
-   expected += "MY_INFO_LEVEL [test_io.cpp->" + std::string(__FUNCTION__) + ":" + std::to_string(line);
+   expected += "MY_INFO_LEVEL [test_io.cpp->" + std::string(G3LOG_PRETTY_FUNCTION) + ":" + std::to_string(line);
    EXPECT_TRUE(verifyContent(file_content, expected)) << file_content
          << "\n\nExpected: \n" << expected;
 }


### PR DESCRIPTION
This would change the current behavior when printing for gcc/clang.

From:

test_io.cpp->TestBody:639

To:

test_io.cpp->virtual void CustomLogLevels_AddANonFatal_Test::TestBody():639

I replaced \_\_FUNCTION__ with \_\_func__ as the fallback because it seems like that is more standard because it is part of the c99/c++11 standards.

However, maybe \_\_FUNCTION__ should be kept for backwards compatibility sake.

I changed the name of the macro, so it doesn't collide with the compiler versions.