### PR TITLE
fix(cmake): fixes #413

### DIFF
--- a/cmake/g3logConfig.cmake
+++ b/cmake/g3logConfig.cmake
@@ -47,7 +47,7 @@ if (NOT TARGET g3log)
    endif ()
 endif ()
 
-find_package_handle_standard_args(G3LOG REQUIRED_VARS G3LOG_INCLUDE_DIR G3LOG_LIBRARY)
+find_package_handle_standard_args(g3log REQUIRED_VARS G3LOG_INCLUDE_DIR G3LOG_LIBRARY)
 mark_as_advanced(G3LOG_INCLUDE_DIR G3LOG_LIBRARY)
 set(G3LOG_INCLUDE_DIRS ${G3LOG_INCLUDE_DIR})
 set(G3LOG_LIBRARIES ${G3LOG_LIBRARY})


### PR DESCRIPTION
# PULL REQUEST DESCRIPTION

This pull request fixes #413. I'm not that familiar with CMake, but it seems to be fixed by just building as `g3log` instead of `G3LOG`. I'm not sure if this has any other negative implications, but the tests run successfully.

# Testing

- [ ] This new/modified code was covered by unit tests. 

- [ ] (insight) Was all tests written using TDD (Test Driven Development) style?

- [x] The CI (Windows, Linux, OSX) are working without issues. 

- [ ] Was new functionality documented? 

- [x] The testing steps  1 - 2 below were followed

_step 1_

```bash 
mkdir build; cd build; cmake -DADD_G3LOG_UNIT_TEST=ON ..

// linux/osx alternative, simply run: ./scripts/buildAndRunTests.sh
```

_step 2: use one of these alternatives to run tests:_

- Cross-Platform: `ctest`
- or `ctest -V` for verbose output
- Linux: `make test`
