### PR TITLE
Resolve noexcept warnings on lambdas

### DIFF
--- a/src/g3log/active.hpp
+++ b/src/g3log/active.hpp
@@ -48,7 +48,7 @@ namespace kjellkod {
 
    public:
       virtual ~Active() {
-         send([this] { done_ = true;});
+         send([this]() noexcept { done_ = true;});
          thd_.join();
       }
 

--- a/src/g3log/logworker.hpp
+++ b/src/g3log/logworker.hpp
@@ -127,7 +127,7 @@ namespace g3 {
       /// This will clear/remove all the sinks. If a sink shared_ptr was retrieved via the sink
       /// handle then the sink will be removed internally but will live on in the client's instance
       void removeAllSinks() {
-         auto bg_clear_sink_call = [this] { _impl._sinks.clear(); };
+         auto bg_clear_sink_call = [this]() noexcept { _impl._sinks.clear(); };
          auto token_cleared = g3::spawn_task(bg_clear_sink_call, _impl._bg.get());
          token_cleared.wait();
       }


### PR DESCRIPTION
When running with additional warnings enabled, a couple lambdas produce a warning that they should be declared with noexcept. This addresses the lambdas that had been identified while building.

Signed-off-by: Ben Magistro <koncept1@gmail.com>

----

Below are the two warnings that we had observed, they were observed under different versions of gcc.  In the interim, we are using a local patch to address this.

```
/opt/rh/devtoolset-9/root/usr/include/c++/9/type_traits: In instantiation of ‘constexpr bool std::__call_is_nt(std::__invoke_other) [with _Fn = g3::LogWorker::removeAllSinks()::<lambda()>&; _Args = {}]’:
/opt/rh/devtoolset-9/root/usr/include/c++/9/type_traits:2750:34:   required by substitution of ‘template<bool __v> using __bool_constant = std::integral_constant<bool, __v> [with bool __v = std::__call_is_nt<g3::LogWorker::removeAllSinks()::<lambda()>&>((std::__result_of_success<void, std::__invoke_other>::__invoke_type{}, std::__result_of_success<void, std::__invoke_other>::__invoke_type()))]’
/opt/rh/devtoolset-9/root/usr/include/c++/9/type_traits:2748:12:   required from ‘struct std::__call_is_nothrow<std::__invoke_result<g3::LogWorker::removeAllSinks()::<lambda()>&>, g3::LogWorker::removeAllSinks()::<lambda()>&>’
/opt/rh/devtoolset-9/root/usr/include/c++/9/type_traits:131:12:   required from ‘struct std::__and_<std::__is_invocable<g3::LogWorker::removeAllSinks()::<lambda()>&>, std::__call_is_nothrow<std::__invoke_result<g3::LogWorker::removeAllSinks()::<lambda()>&>, g3::LogWorker::removeAllSinks()::<lambda()>&> >’
/opt/rh/devtoolset-9/root/usr/include/c++/9/type_traits:2760:12:   required from ‘struct std::__is_nothrow_invocable<g3::LogWorker::removeAllSinks()::<lambda()>&>’
/opt/rh/devtoolset-9/root/usr/include/c++/9/bits/invoke.h:89:5:   required from ‘constexpr typename std::__invoke_result<_Functor, _ArgTypes>::type std::__invoke(_Callable&&, _Args&& ...) [with _Callable = g3::LogWorker::removeAllSinks()::<lambda()>&; _Args = {}; typename std::__invoke_result<_Functor, _ArgTypes>::type = void]’
/opt/rh/devtoolset-9/root/usr/include/c++/9/future:1421:26:   required from ‘void std::__future_base::_Task_state<_Fn, _Alloc, _Res(_Args ...)>::_M_run(_Args&& ...) [with _Fn = g3::LogWorker::removeAllSinks()::<lambda()>; _Alloc = std::allocator<int>; _Res = void; _Args = {}]’
/opt/rh/devtoolset-9/root/usr/include/c++/9/future:1418:7:   required from here
/tmp/stack/build/_deps/g3log-src/src/g3log/logworker.hpp:130:36: warning: but ‘g3::LogWorker::removeAllSinks()::<lambda()>’ does not throw; perhaps it should be declared ‘noexcept’ [-Wnoexcept]
  130 |          auto bg_clear_sink_call = [this] { _impl._sinks.clear(); };
      |                                    ^
```

```
/opt/rh/devtoolset-11/root/usr/include/c++/11/type_traits: In instantiation of ‘constexpr bool std::__call_is_nt(std::__invoke_other) [with _Fn = kjellkod::Active::~Active()::<lambda()>&; _Args = {}]’:
/opt/rh/devtoolset-11/root/usr/include/c++/11/type_traits:2966:34:   required from ‘struct std::__call_is_nothrow<std::__invoke_result<kjellkod::Active::~Active()::<lambda()>&>, kjellkod::Active::~Active()::<lambda()>&>’
/opt/rh/devtoolset-11/root/usr/include/c++/11/type_traits:152:12:   required from ‘struct std::__and_<std::__is_nt_invocable_impl<std::__invoke_result<kjellkod::Active::~Active()::<lambda()>&>, void, void>, std::__call_is_nothrow<std::__invoke_result<kjellkod::Active::~Active()::<lambda()>&>, kjellkod::Active::~Active()::<lambda()>&> >’
/opt/rh/devtoolset-11/root/usr/include/c++/11/type_traits:3064:12:   required from ‘struct std::is_nothrow_invocable_r<void, kjellkod::Active::~Active()::<lambda()>&>’
/opt/rh/devtoolset-11/root/usr/include/c++/11/type_traits:3269:52:   required from ‘constexpr const bool std::is_nothrow_invocable_r_v<void, kjellkod::Active::~Active()::<lambda()>&>’
/opt/rh/devtoolset-11/root/usr/include/c++/11/bits/invoke.h:105:14:   required from ‘constexpr std::enable_if_t<is_invocable_r_v<_Res, _Callable, _Args ...>, _Res> std::__invoke_r(_Callable&&, _Args&& ...) [with _Res = void; _Callable = kjellkod::Active::~Active()::<lambda()>&; _Args = {}; std::enable_if_t<is_invocable_r_v<_Res, _Callable, _Args ...>, _Res> = void]’
/opt/rh/devtoolset-11/root/usr/include/c++/11/bits/std_function.h:290:30:   required from ‘static _Res std::_Function_handler<_Res(_ArgTypes ...), _Functor>::_M_invoke(const std::_Any_data&, _ArgTypes&& ...) [with _Res = void; _Functor = kjellkod::Active::~Active()::<lambda()>; _ArgTypes = {}]’
/opt/rh/devtoolset-11/root/usr/include/c++/11/bits/std_function.h:451:21:   required from ‘std::function<_Res(_ArgTypes ...)>::function(_Functor&&) [with _Functor = kjellkod::Active::~Active()::<lambda()>; _Constraints = void; _Res = void; _ArgTypes = {}]’
/tmp/stack/build/_deps/g3log-src/src/g3log/active.hpp:51:14:   required from here
/opt/rh/devtoolset-11/root/usr/include/c++/11/type_traits:2960:14: warning: noexcept-expression evaluates to ‘false’ because of a call to ‘kjellkod::Active::~Active()::<lambda()>’ [-Wnoexcept]
 2960 |       return noexcept(std::declval<_Fn>()(std::declval<_Args>()...));
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /tmp/stack/build/_deps/g3log-src/src/g3log/sink.hpp:13,
                 from /tmp/stack/build/_deps/g3log-src/src/g3log/sinkhandle.hpp:11,
                 from /tmp/stack/build/_deps/g3log-src/src/g3log/logworker.hpp:16,
                 from /tmp/stack/library/common/include/Logging.hpp:6,
                 from /tmp/stack/library/libcomb/src/CombinationEngine.cpp:1:
/tmp/stack/build/_deps/g3log-src/src/g3log/active.hpp:51:15: note: but ‘kjellkod::Active::~Active()::<lambda()>’ does not throw; perhaps it should be declared ‘noexcept’
   51 |          send([this] { done_ = true;});
      |               ^
```