### PR TITLE
exitWithDefaultSignalHandler() should block until signal handler returns

### DIFF
--- a/src/crashhandler_unix.cpp
+++ b/src/crashhandler_unix.cpp
@@ -230,7 +230,7 @@ namespace g3 {
          std::cerr << "\n\n" << __FUNCTION__ << ":" << __LINE__ << ". Exiting due to " << level.text << ", " << signal_number << "   \n\n" << std::flush;
 
 
-         kill(getpid(), signal_number);
+         raise(signal_number);
 
          // When running as PID1 the above kill doesn't have any effect (execution simply passes through it, contrary
          // to a non-PID1 process where execution stops at kill and switches over to signal handling). Also as PID1 


### PR DESCRIPTION
raise() system call does the same as kill() system call in a single-threaded program.
In a multithreaded program, it does the same as pthread_kill() which ensures that if the signal causes a handler to be called, raise() will return only after the signal handler has returned.


# PULL REQUEST DESCRIPTION

In unix version of g3::internal::exitWithDefaultSignalHandler(), it rethrows the signal using the kill() system call.
This system call is per process basis. 
In a multithreaded program, if the signal causes a handler to be called, the handler can be executed in any thread, not necessary by the thread that calls kill().
It means that the calling thread can continue and reach the exit() system call.
In the case of a signal that terminate the process and dump core, the coredump file may be corrupted because the exit() initiates the destruction of main objects, that could be useful for the crash analysis.
raise() sends a signal to the calling thread, if the signal causes a handler to be called, the thread execution will block until that handler returns, the exit() is never reached, core file integrity is preserved.

# Testing

- Tested in real environment with a multithreaded program

_Call stack with kill() system call_

```
(gdb) bt
#0  0x00007ff6bf8a685f in _dl_fixup (l=0x7ff6bf88fab0, reloc_arg=5518) at dl-runtime.c:67
#1  0x00007ff6bf893d5e in _dl_runtime_resolve_xsavec () at ../sysdeps/x86_64/dl-trampoline.h:126
#2  0x00007ff6bc54c3e6 in std::map<std::basic_string_view<char, std::char_traits<char> >, SdpMediaDescription::eProtocolType, std::less<std::basic_string_view<char, std::char_traits<char> > >, std::allocator<std::pair<std::basic_string_view<char, std::char_traits<char> > const, SdpMediaDescription::eProtocolType> > >::~map (
    this=0x7ff6bcac7c00 <protoFrom(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::sc_protosMap>, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/stl_map.h:302
#3  0x00007ff6b99b0a15 in __run_exit_handlers () from /lib64/libc.so.6
#4  0x00007ff6b99b0b90 in exit () from /lib64/libc.so.6
#5  0x00007ff6ba9aec79 in g3::internal::exitWithDefaultSignalHandler (level=..., fatal_signal_id=11) at /tmp/src/ng_src-fmk/extern/g3log/src/crashhandler_unix.cpp:240
#6  0x00007ff6ba9c2cbb in g3::LogWorkerImpl::bgFatal (this=0x1863e50, msgPtr=...) at /tmp/src/ng_src-fmk/extern/g3log/src/logworker.cpp:67
#7  0x00007ff6ba9c2f91 in operator() (__closure=0x7ff6a80065a0) at /tmp/src/ng_src-fmk/extern/g3log/src/logworker.cpp:109
#8  0x00007ff6ba9c3e4c in std::__invoke_impl<void, g3::LogWorker::fatal(g3::FatalMessagePtr)::<lambda()>&>(std::__invoke_other, struct {...} &) (__f=...) at /usr/include/c++/11/bits/invoke.h:61
#9  0x00007ff6ba9c3b86 in std::__invoke_r<void, g3::LogWorker::fatal(g3::FatalMessagePtr)::<lambda()>&>(struct {...} &) (__fn=...) at /usr/include/c++/11/bits/invoke.h:111
#10 0x00007ff6ba9c37d7 in std::_Function_handler<void(), g3::LogWorker::fatal(g3::FatalMessagePtr)::<lambda()> >::_M_invoke(const std::_Any_data &) (__functor=...) at /usr/include/c++/11/bits/std_function.h:291
#11 0x00000000004cd15b in std::function<void ()>::operator()() const (this=0x7ff6b9795cd0) at /usr/include/c++/11/bits/std_function.h:560
#12 0x00000000004c9e59 in kjellkod::Active::run (this=0x1863e80) at /tmp/build/g3log/include/g3log/active.hpp:40
#13 0x00000000004f4829 in std::__invoke_impl<void, void (kjellkod::Active::*)(), kjellkod::Active*> (__f=@0x18641c0: (void (kjellkod::Active::*)(kjellkod::Active * const)) 0x4c9db6 <kjellkod::Active::run()>, __t=@0x18641b8: 0x1863e80)
    at /usr/include/c++/11/bits/invoke.h:74
#14 0x00000000004f405f in std::__invoke<void (kjellkod::Active::*)(), kjellkod::Active*> (__fn=@0x18641c0: (void (kjellkod::Active::*)(kjellkod::Active * const)) 0x4c9db6 <kjellkod::Active::run()>)
    at /usr/include/c++/11/bits/invoke.h:96
#15 0x00000000004f397e in std::thread::_Invoker<std::tuple<void (kjellkod::Active::*)(), kjellkod::Active*> >::_M_invoke<0ul, 1ul> (this=0x18641b8) at /usr/include/c++/11/bits/std_thread.h:253
#16 0x00000000004f31d9 in std::thread::_Invoker<std::tuple<void (kjellkod::Active::*)(), kjellkod::Active*> >::operator() (this=0x18641b8) at /usr/include/c++/11/bits/std_thread.h:260
#17 0x00000000004f2bd3 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (kjellkod::Active::*)(), kjellkod::Active*> > >::_M_run (this=0x18641b0) at /usr/include/c++/11/bits/std_thread.h:211
#18 0x00007ff6ba6a1c84 in execute_native_thread_routine () from /lib64/libstdc++.so.6
#19 0x00007ff6b99f8da2 in start_thread () from /lib64/libc.so.6
#20 0x00007ff6b99989e0 in clone3 () from /lib64/libc.so.6
(gdb)
```

At frame 5, fatal_signal_id indicates that a SIGSEGV triggered the fatal log message.
At frame 2 a global std::map is destroyed.

_Call stack with raise() system call_

This is the exact same issue but the kill() system call is replaced by raise().

```
(gdb) bt
#0  0x00007f6bfee90aec in __pthread_kill_implementation () from /lib64/libc.so.6
#1  0x00007f6bfee442a6 in raise () from /lib64/libc.so.6
#2  0x00007f6bffe44c52 in g3::internal::exitWithDefaultSignalHandler (level=..., fatal_signal_id=11) at /tmp/src/ng_src-fmk/extern/g3log/src/crashhandler_unix.cpp:228
#3  0x00007f6bffe58cb1 in g3::LogWorkerImpl::bgFatal (this=0x90be50, msgPtr=...) at /tmp/src/ng_src-fmk/extern/g3log/src/logworker.cpp:67
#4  0x00007f6bffe58f87 in operator() (__closure=0x7f6bf4004890) at /tmp/src/ng_src-fmk/extern/g3log/src/logworker.cpp:109
#5  0x00007f6bffe59e42 in std::__invoke_impl<void, g3::LogWorker::fatal(g3::FatalMessagePtr)::<lambda()>&>(std::__invoke_other, struct {...} &) (__f=...) at /usr/include/c++/11/bits/invoke.h:61
#6  0x00007f6bffe59b7c in std::__invoke_r<void, g3::LogWorker::fatal(g3::FatalMessagePtr)::<lambda()>&>(struct {...} &) (__fn=...) at /usr/include/c++/11/bits/invoke.h:111
#7  0x00007f6bffe597cd in std::_Function_handler<void(), g3::LogWorker::fatal(g3::FatalMessagePtr)::<lambda()> >::_M_invoke(const std::_Any_data &) (__functor=...) at /usr/include/c++/11/bits/std_function.h:291
#8  0x00000000004cd15b in std::function<void ()>::operator()() const (this=0x7f6bfec2bcd0) at /usr/include/c++/11/bits/std_function.h:560
#9  0x00000000004c9e59 in kjellkod::Active::run (this=0x90be80) at /tmp/build/g3log/include/g3log/active.hpp:40
#10 0x00000000004f4829 in std::__invoke_impl<void, void (kjellkod::Active::*)(), kjellkod::Active*> (__f=@0x90c1c0: (void (kjellkod::Active::*)(kjellkod::Active * const)) 0x4c9db6 <kjellkod::Active::run()>, __t=@0x90c1b8: 0x90be80) at /usr/include/c++/11/bits/invoke.h:74
#11 0x00000000004f405f in std::__invoke<void (kjellkod::Active::*)(), kjellkod::Active*> (__fn=@0x90c1c0: (void (kjellkod::Active::*)(kjellkod::Active * const)) 0x4c9db6 <kjellkod::Active::run()>) at /usr/include/c++/11/bits/invoke.h:96
#12 0x00000000004f397e in std::thread::_Invoker<std::tuple<void (kjellkod::Active::*)(), kjellkod::Active*> >::_M_invoke<0ul, 1ul> (this=0x90c1b8) at /usr/include/c++/11/bits/std_thread.h:253
#13 0x00000000004f31d9 in std::thread::_Invoker<std::tuple<void (kjellkod::Active::*)(), kjellkod::Active*> >::operator() (this=0x90c1b8) at /usr/include/c++/11/bits/std_thread.h:260
#14 0x00000000004f2bd3 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (kjellkod::Active::*)(), kjellkod::Active*> > >::_M_run (this=0x90c1b0) at /usr/include/c++/11/bits/std_thread.h:211
#15 0x00007f6bffb37c84 in execute_native_thread_routine () from /lib64/libstdc++.so.6
#16 0x00007f6bfee8eda2 in start_thread () from /lib64/libc.so.6
#17 0x00007f6bfee2e9e0 in clone3 () from /lib64/libc.so.6
(gdb)
```

At frame 2, fatal_signal_id indicates that a SIGSEGV triggered the fatal log message.