### PR TITLE
__SIGFUNC__ no longer default for Windows. __PRETTY__FUNCTION no longer default for gcc/clang

### DIFF
--- a/Options.cmake
+++ b/Options.cmake
@@ -15,6 +15,7 @@
 #   add_definitions(-DG3_DYNAMIC_LOGGING)
 #   add_definitions(-DCHANGE_G3LOG_DEBUG_TO_DBUG)
 #   add_definitions(-DWINDOWS_FUNCSIG)
+#   add_definitions(-DPRETTY_FUNCTION)
 #   add_definitions(-DDISABLE_FATAL_SIGNALHANDLING)
 #   add_definitions(-DDISABLE_VECTORED_EXCEPTIONHANDLING)
 #   add_definitions(-DDEBUG_BREAK_AT_FATAL_SIGNAL)
@@ -62,9 +63,7 @@ ELSE()
 ENDIF(CHANGE_G3LOG_DEBUG_TO_DBUG)
 
 
-# -DWINDOWS_USE_FUNCSIG=ON   : Override the use of __FUNCTION__ for Windows platform and instead use __FUNCSIG__
-# WARNING: if using heavy templated integrations such as boost log calls that shows the function name (this is the default) 
-# can be spammed by the expanded template definitions. 
+# -DWINDOWS_USE_FUNCSIG=ON   : (Default OFF) Override the use of __FUNCTION__ for Windows platform and instead use __FUNCSIG__
 option (WINDOWS_FUNCSIG
        "Windows __FUNCSIG__ to expand `Function` location of the LOG call instead of the default __FUNCTION__" OFF)
 IF(WINDOWS_FUNCSIG)
@@ -73,6 +72,20 @@ IF(WINDOWS_FUNCSIG)
 ELSE() 
    message( STATUS "-DWINDOWS_FUNCSIG=OFF\t\t") 
 ENDIF(WINDOWS_FUNCSIG)
+
+
+# -DPRETTY_FUNCTION=ON   : (Default OFF) Override the use of __FUNCTION__ for Windows platform and instead use __FUNCSIG__
+# NOTE: heavy templated integrations such as boost log calls that shows the function name can cause function name expansion
+# to "spam" the LOG output with the now visible template arguments. 
+option (PRETTY_FUNCTION
+       "Windows __PRETTY_FUNCTION__ to expand `Function` location of the LOG call instead of the default __FUNCTION__" OFF)
+IF(PRETTY_FUNCTION)
+   LIST(APPEND G3_DEFINITIONS PRETTY_FUNCTION)
+   message( STATUS "-DPRETTY_FUNCTION=ON\t\t__PRETTY_FUNCTION__ is used instead of the default __FUNCTION__ for LOG call locations" )
+ELSE() 
+   message( STATUS "-DPRETTY_FUNCTION=OFF\t\t") 
+ENDIF(PRETTY_FUNCTION)
+
 
 
 # -DG3_DYNAMIC_MAX_MESSAGE_SIZE   : use dynamic memory for final_message in logcapture.cpp

--- a/Options.cmake
+++ b/Options.cmake
@@ -70,7 +70,7 @@ IF(WINDOWS_FUNCSIG)
    LIST(APPEND G3_DEFINITIONS WINDOWS_FUNCSIG)
    message( STATUS "-DWINDOWS_FUNCSIG=ON\t\t__SIGFUNC__ is used instead of the default __FUNCTION__ for LOG call locations" )
 ELSE() 
-   message( STATUS "-DWINDOWS_FUNCSIG=OFF\t\t") 
+   message( STATUS "-DWINDOWS_FUNCSIG=OFF") 
 ENDIF(WINDOWS_FUNCSIG)
 
 
@@ -83,7 +83,7 @@ IF(PRETTY_FUNCTION)
    LIST(APPEND G3_DEFINITIONS PRETTY_FUNCTION)
    message( STATUS "-DPRETTY_FUNCTION=ON\t\t__PRETTY_FUNCTION__ is used instead of the default __FUNCTION__ for LOG call locations" )
 ELSE() 
-   message( STATUS "-DPRETTY_FUNCTION=OFF\t\t") 
+   message( STATUS "-DPRETTY_FUNCTION=OFF") 
 ENDIF(PRETTY_FUNCTION)
 
 

--- a/Options.cmake
+++ b/Options.cmake
@@ -14,6 +14,7 @@
 # to the auto generated file src/g3log/generated_definitions.hpp
 #   add_definitions(-DG3_DYNAMIC_LOGGING)
 #   add_definitions(-DCHANGE_G3LOG_DEBUG_TO_DBUG)
+#   add_definitions(-DWINDOWS_FUNCSIG)
 #   add_definitions(-DDISABLE_FATAL_SIGNALHANDLING)
 #   add_definitions(-DDISABLE_VECTORED_EXCEPTIONHANDLING)
 #   add_definitions(-DDEBUG_BREAK_AT_FATAL_SIGNAL)
@@ -59,6 +60,19 @@ ELSE()
    LIST(APPEND G3_DEFINITIONS "G3LOG_DEBUG DEBUG")
    message( STATUS "-DCHANGE_G3LOG_DEBUG_TO_DBUG=OFF \t(Debuggin logging level is 'DEBUG')" ) 
 ENDIF(CHANGE_G3LOG_DEBUG_TO_DBUG)
+
+
+# -DWINDOWS_USE_FUNCSIG=ON   : Override the use of __FUNCTION__ for Windows platform and instead use __FUNCSIG__
+# WARNING: if using heavy templated integrations such as boost log calls that shows the function name (this is the default) 
+# can be spammed by the expanded template definitions. 
+option (WINDOWS_FUNCSIG
+       "Windows __FUNCSIG__ to expand `Function` location of the LOG call instead of the default __FUNCTION__" OFF)
+IF(WINDOWS_FUNCSIG)
+   LIST(APPEND G3_DEFINITIONS WINDOWS_FUNCSIG)
+   message( STATUS "-DWINDOWS_FUNCSIG=ON\t\t__SIGFUNC__ is used instead of the default __FUNCTION__ for LOG call locations" )
+ELSE() 
+   message( STATUS "-DWINDOWS_FUNCSIG=OFF\t\t") 
+ENDIF(WINDOWS_FUNCSIG)
 
 
 # -DG3_DYNAMIC_MAX_MESSAGE_SIZE   : use dynamic memory for final_message in logcapture.cpp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ before_build:
   - cd build
 
 build_script:
-  - cmake -G "Visual Studio 15 2017 Win64" -DADD_G3LOG_UNIT_TEST=ON -DUSE_DYNAMIC_LOGGING_LEVELS=ON -DCHANGE_G3LOG_DEBUG_TO_DBUG=ON -DCMAKE_INSTALL_PREFIX=c:\g3log ..
+  - cmake -G "Visual Studio 15 2017 Win64" -DADD_G3LOG_UNIT_TEST=ON -DWINDOWS_FUNCSIG=ON -DUSE_DYNAMIC_LOGGING_LEVELS=ON -DCHANGE_G3LOG_DEBUG_TO_DBUG=ON -DCMAKE_INSTALL_PREFIX=c:\g3log ..
   - cmake --build . --config Release --target install
 
 # scripts to run after build

--- a/docs/building.md
+++ b/docs/building.md
@@ -47,6 +47,13 @@ ADD_G3LOG_UNIT_TEST:BOOL=OFF
 // By default DEBUG is the debugging level
 CHANGE_G3LOG_DEBUG_TO_DBUG:BOOL=OFF
 
+
+// Windows only: Use __FUNCSIG__ instead of the default __FUNCTION__ 
+// to show LOG function location
+// WARNING: using this in heavily templated code, like boost can expand
+// the function name into massive size
+WINDOWS_FUNCSIG:BOOL=OFF
+
 // Specifies the build type on single-configuration generators.
 // Possible values are empty, Debug, Release, RelWithDebInfo, MinSizeRel, …
 CMAKE_BUILD_TYPE:STRING=

--- a/docs/building.md
+++ b/docs/building.md
@@ -54,6 +54,14 @@ CHANGE_G3LOG_DEBUG_TO_DBUG:BOOL=OFF
 // the function name into massive size
 WINDOWS_FUNCSIG:BOOL=OFF
 
+
+// gcc/clang only: Use __PRETTY_FUNCTION__ instead of the default __FUNCTION__ 
+// to show LOG function location
+// WARNING: using this in heavily templated code, like boost can expand
+// the function name into massive size
+PRETTY_FUNCTION:BOOL=OFF
+
+
 // Specifies the build type on single-configuration generators.
 // Possible values are empty, Debug, Release, RelWithDebInfo, MinSizeRel, …
 CMAKE_BUILD_TYPE:STRING=

--- a/scripts/buildAndRunTests.sh
+++ b/scripts/buildAndRunTests.sh
@@ -6,7 +6,7 @@ set -x
 
 mkdir -p  build_travis
 cd build_travis
-cmake -DADD_G3LOG_BENCH_PERFORMANCE=ON -DADD_G3LOG_UNIT_TEST=ON -DCMAKE_INSTALL_PREFIX=./install -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/g3log ..
+cmake -DADD_G3LOG_BENCH_PERFORMANCE=ON -DPRETTY_FUNCTION=ON -DADD_G3LOG_UNIT_TEST=ON -DCMAKE_INSTALL_PREFIX=./install -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/g3log ..
 cmake --build . --target install
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/src/g3log/g3log.hpp
+++ b/src/g3log/g3log.hpp
@@ -33,7 +33,7 @@
 #define G3LOG_PRETTY_FUNCTION __FUNCSIG__
 #elif defined(__GNUC__) && defined(PRETTY_FUNCTION) // GCC compatible
 #define G3LOG_PRETTY_FUNCTION __PRETTY_FUNCTION__
-#else // unknown land, let's use basic __FUNCITON__
+#else 
 #define G3LOG_PRETTY_FUNCTION __FUNCTION__
 #endif
 

--- a/src/g3log/g3log.hpp
+++ b/src/g3log/g3log.hpp
@@ -31,13 +31,10 @@
 
 #if defined(_MSC_VER) && (defined(WINDOWS_FUNCSIG)) // Microsoft
 #define G3LOG_PRETTY_FUNCTION __FUNCSIG__
-#pragma message("G3LOG_PRETTY_FUNCTION is set to __FUNCSIG__")
-#elif defined(__GNUC__) // GCC compatible
+#elif defined(__GNUC__) && defined(PRETTY_FUNCTION) // GCC compatible
 #define G3LOG_PRETTY_FUNCTION __PRETTY_FUNCTION__
-#pragma message("G3LOG_PRETTY_FUNCTION is set to __PRETTY_FUNCTION__")
 #else // unknown land, let's use basic __FUNCITON__
 #define G3LOG_PRETTY_FUNCTION __FUNCTION__
-#pragma message("G3LOG_PRETTY_FUNCTION is set to __FUNCTION__")
 #endif
 
 // thread_local doesn't exist before VS2013

--- a/src/g3log/g3log.hpp
+++ b/src/g3log/g3log.hpp
@@ -29,13 +29,15 @@
 #include <string>
 #include <functional>
 
-
-#if defined(__GNUC__)   // GCC extension compatible
-#define G3LOG_PRETTY_FUNCTION __PRETTY_FUNCTION__
-#elif defined(_MSC_VER) // Microsoft
+#if defined(_MSC_VER) && (defined(WINDOWS_FUNCSIG)) // Microsoft
 #define G3LOG_PRETTY_FUNCTION __FUNCSIG__
-#else                   // __func__ is fallback to c99 / c++11, where that doesn't matter so __FUNCTION__ is the choice
+#pragma message("G3LOG_PRETTY_FUNCTION is set to __FUNCSIG__")
+#elif defined(__GNUC__) // GCC compatible
+#define G3LOG_PRETTY_FUNCTION __PRETTY_FUNCTION__
+#pragma message("G3LOG_PRETTY_FUNCTION is set to __PRETTY_FUNCTION__")
+#else // unknown land, let's use basic __FUNCITON__
 #define G3LOG_PRETTY_FUNCTION __FUNCTION__
+#pragma message("G3LOG_PRETTY_FUNCTION is set to __FUNCTION__")
 #endif
 
 // thread_local doesn't exist before VS2013


### PR DESCRIPTION
__SIGFUNC__ no longer default for Windows, It has to be explicitly picked through CMAKE option

