### PR TITLE
Parse OSX stack dump format in order to demangle it correctly

### DIFF
--- a/src/crashhandler_unix.cpp
+++ b/src/crashhandler_unix.cpp
@@ -199,7 +199,7 @@ namespace g3 {
             }
          } // END: for(size_t idx = 1; idx < size && messages != nullptr; ++idx)
          free(messages);
-         return oss.str()
+         return oss.str();
       }
 
 


### PR DESCRIPTION
# PULL REQUEST DESCRIPTION

Parsing of stack dump coming from OSX was ignoring the different format of it.
Previously it was looking for a format similar to this `./bt_example(_Z3bazv+0x14)[0x4009db]` in which mangled name and offset are contained in brackets. 
In this PR I wanted to add handling of different dump format - `3 bt_example  0x000000010dd39eb9 _Z3barv + 9` in which the mangled name is starting with an underscore and is followed by a space and the `+` sign separated offset.

# Testing

-  Tested in a real environment with a multithreaded program
