### PR TITLE
Fix FileSink dropping messages 

### DIFF
--- a/src/filesink.cpp
+++ b/src/filesink.cpp
@@ -67,7 +67,7 @@ namespace g3 {
 
       _write_buffer.append(data);
       if (++_write_counter % _write_to_log_every_x_message == 0) {
-         out << message.get().toString(_log_details_func) << std::flush;
+         out << _write_buffer << std::flush;
          _write_buffer.clear();
       }
    }


### PR DESCRIPTION
# PULL REQUEST DESCRIPTION

Fix FileSink dropping messages introduced by 'optionable buffer to x messages' feature

Commit 6c6122fafc79e92fc94a851b3ff83f87e8b80398 introduced a bug where 99 out of 100 logs were actually dumped

Bug discovered while using two sinks : FileSink and the stdout example sink. I had every messages in stdout sink, but very few in the log file.

# Testing

- [ ] This new/modified code was covered by unit tests. 

- [ ] (insight) Was all tests written using TDD (Test Driven Development) style?

- [ ] The CI (Windows, Linux, OSX) are working without issues. 

- [ ] Was new functionality documented? 

- [x] The testing steps  1 - 2 below were followed

- [x] Tested manually to check that messages were correctly written to file.

_step 1_

```bash 
mkdir build; cd build; cmake -DADD_G3LOG_UNIT_TEST=ON ..

// linux/osx alternative, simply run: ./scripts/buildAndRunTests.sh
```

_step 2: use one of these alternatives to run tests:_

- Cross-Platform: `ctest`
- or `ctest -V` for verbose output
- Linux: `make test`
