### PR TITLE
Avoid pending of containerized applications in case of aborting

### DIFF
--- a/src/crashhandler_unix.cpp
+++ b/src/crashhandler_unix.cpp
@@ -235,8 +235,8 @@ namespace g3 {
       void exitWithDefaultSignalHandler(const LEVELS& level, g3::SignalType fatal_signal_id) {
          const int signal_number = static_cast<int>(fatal_signal_id);
           
-         // Restore all signals to handle by the saved handlers. If handling a signal which causes exiting 
-         // then other signals are handled by the original signal handler.
+         // Restore all saved signal handlers. If handling a signal which causes exiting 
+         // than let the original signal handlers to handle other signals.
          for (const auto& sig : gSignals) {
             restoreSignalHandler(sig.first);
          }

--- a/src/crashhandler_unix.cpp
+++ b/src/crashhandler_unix.cpp
@@ -62,15 +62,16 @@ namespace {
    // ALL thanks to this thread at StackOverflow. Pretty much borrowed from:
    // Ref: http://stackoverflow.com/questions/77005/how-to-generate-a-stacktrace-when-my-gcc-c-app-crashes
    void signalHandler(int signal_number, siginfo_t* /*info*/, void* /*unused_context*/) {
-
+      
+      using namespace g3::internal;
+      
       // Only one signal will be allowed past this point
       if (false == shouldDoExit()) {
-         while (true) {
+         while (shouldBlockForFatalHandling()) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
          }
       }
 
-      using namespace g3::internal;
       {
          const auto dump = stackdump();
          std::ostringstream fatal_stream;
@@ -233,7 +234,13 @@ namespace g3 {
       // --- If LOG(FATAL) or CHECK(false) the signal_number will be SIGABRT
       void exitWithDefaultSignalHandler(const LEVELS& level, g3::SignalType fatal_signal_id) {
          const int signal_number = static_cast<int>(fatal_signal_id);
-         restoreSignalHandler(signal_number);
+          
+         // Restore all signals to handle by the saved handlers. If handling a signal which causes exiting 
+         // then other signals are handled by the original signal handler.
+         for (const auto& sig : gSignals) {
+            restoreSignalHandler(sig.first);
+         }
+         
          std::cerr << "\n\n" << __FUNCTION__ << ":" << __LINE__ << ". Exiting due to " << level.text << ", " << signal_number << "   \n\n" << std::flush;
 
 


### PR DESCRIPTION
# PULL REQUEST DESCRIPTION
This pull request contains the proposed solution for the issue:
https://github.com/KjellKod/g3log/issues/480

Similar issue was solved in PR:
https://github.com/KjellKod/g3log/pull/419

Our containerized application (running in Docker container PID 1) was tested with crashing due to SIGABRT signal. After SIGABRT was dropped then unfortunatlly infinite SIGSEGV signals were also started to drop. So the infinite loop stucked since the kill signal doesn't stop the infinite loop when running in Docker container with PID 1. Similar solution was happened in this PR: https://github.com/KjellKod/g3log/pull/419. We also had to restore the saved signal handlers. Without it infinte SIGSEGV signals were dropped circully and this situation could also cause pending when running in Docker container with PID 1.
The modification does not affect non-containerized native processes (non-PID1) as the final step after the flush is re-emitting the fatal signal (kill) and code execution for the process stops here. This solution enables the containerized process to exit and create a core-dump also in case of aborting scenarios and more generally when different signal(s) occurs after a crash but before the exit.

There are no testing or documentation activities done.

# Testing
New/modified code must be backed down with unit test - preferably TDD style development)

- [ ] This new/modified code was covered by unit tests. 

- [ ] (insight) Was all tests written using TDD (Test Driven Development) style?

- [ ] The CI (Windows, Linux, OSX) are working without issues. 

- [ ] Was new functionality documented? 

- [ ] The testing steps  1 - 2 below were followed

_step 1_

```bash 
mkdir build; cd build; cmake -DADD_G3LOG_UNIT_TEST=ON ..

// linux/osx alternative, simply run: ./scripts/buildAndRunTests.sh
```

_step 2: use one of these alternatives to run tests:_

- Cross-Platform: `ctest`
- or `ctest -V` for verbose output
- Linux: `make test`
