### PR TITLE
constexpr LEVELS for easier custom level usage

### DIFF
--- a/src/g3log/loglevels.hpp
+++ b/src/g3log/loglevels.hpp
@@ -34,6 +34,10 @@ struct LEVELS {
    // "dynamic, runtime loading of shared libraries"
 
    LEVELS(const LEVELS& other): value(other.value), text(other.text.c_str()) {}
+
+   #if __cplusplus >= 202002L
+      constexpr
+   #endif
    LEVELS(int id, const std::string& idtext) : value(id), text(idtext) {}
 
    bool operator==(const LEVELS& rhs)  const {
@@ -90,11 +94,15 @@ namespace g3 {
    static const int kInternalFatalValue = 2000;
 } // g3
 
-
-const LEVELS G3LOG_DEBUG{g3::kDebugValue, {"DEBUG"}},
-   INFO {g3::kInfoValue, {"INFO"}},
-   WARNING {g3::kWarningValue, {"WARNING"}},
-   FATAL {g3::kFatalValue, {"FATAL"}};
+#if __cplusplus >= 202002L
+   constexpr
+#else
+   const
+#endif
+LEVELS G3LOG_DEBUG{g3::kDebugValue, "DEBUG"},
+   INFO {g3::kInfoValue, "INFO"},
+   WARNING {g3::kWarningValue, "WARNING"},
+   FATAL {g3::kFatalValue, "FATAL"};
 
 
 
@@ -129,7 +137,12 @@ namespace g3 {
 
 namespace g3 {
    namespace internal {
-      const LEVELS CONTRACT {g3::kInternalFatalValue, {"CONTRACT"}},
+      #if __cplusplus >= 202002L
+         constexpr
+      #else
+         const
+      #endif
+      LEVELS CONTRACT {g3::kInternalFatalValue, {"CONTRACT"}},
             FATAL_SIGNAL {g3::kInternalFatalValue + 1, {"FATAL_SIGNAL"}},
             FATAL_EXCEPTION {kInternalFatalValue + 2, {"FATAL_EXCEPTION"}};
 


### PR DESCRIPTION
Usage of C++20's new constexpr functionalities for easier usage of custom LEVELS!

Modified:
* With C++20 LEVELS's constructor can have a constexpr specifier
* const LEVELS can be replaced to be constexpr's instead


# PULL REQUEST DESCRIPTION

Easy, but not too readable solution.

```
#if __cplusplus >= 202002L
```

This functionality provides an easier usage of custom log levels as value can be used within switch statements.
No explicit constant is required to store & work with custom LEVEL's value.

```
		//  TRACE is between DBUG and INFO
	constexpr LEVELS TRACE { (DBUG.value + INFO.value) / 2, "TRACE"};

	void ReceiveLogMessage( g3::LogMessageMover logEntry)
	{
		switch ( logEntry.get()._level)
		{
			case my_namespace::TRACE.value:
			...
			case g3::kWarningValue:
			...
		}
```

Warning:
On the example above 'DBUG' is used as 'CHANGE_G3LOG_DEBUG_TO_DBUG' cmake option was set.


# Testing

- [ ] This new/modified code was covered by unit tests. 

- [ ] (insight) Was all tests written using TDD (Test Driven Development) style?

- [ ] The CI (Windows, Linux, OSX) are working without issues. 

- [ ] Was new functionality documented? 

- [ ] The testing steps  1 - 2 below were followed

_step 1_

```bash 
mkdir build; cd build; cmake -DADD_G3LOG_UNIT_TEST=ON ..

// linux/osx alternative, simply run: ./scripts/buildAndRunTests.sh
```

_step 2: use one of these alternatives to run tests:_

- Cross-Platform: `ctest`
- or `ctest -V` for verbose output
- Linux: `make test`
