### PR TITLE
Allow to name g3log worker threads

### DIFF
--- a/src/active.cpp
+++ b/src/active.cpp
@@ -1,0 +1,95 @@
+/** ==========================================================================
+ * 2012 by KjellKod.cc. This is PUBLIC DOMAIN to use at your own risk and comes
+ * with no warranties. This code is yours to share, use and modify with no
+ * strings attached and no restrictions or obligations.
+ *
+ * For more information see g3log/LICENSE or refer refer to http://unlicense.org
+ * ============================================================================*/
+
+#include "g3log/active.hpp"
+
+#include <string>
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <pthread.h>
+#endif
+
+namespace kjellkod {
+   namespace internal {
+      native_thread_name getThreadName(std::thread::native_handle_type handle) {
+#ifdef WIN32
+         static auto getThreadDescription =
+            reinterpret_cast<HRESULT(WINAPI *)(HANDLE, PWSTR*)>(::GetProcAddress(
+               ::GetModuleHandleW(L"Kernel32.dll"), "GetThreadDescription"));
+         if (getThreadDescription == nullptr) {
+            return native_thread_name();
+         }
+
+         wchar_t *wide_thread_name;
+         HRESULT hr = getThreadDescription(handle, &wide_thread_name);
+         if (SUCCEEDED(hr)) {
+            native_thread_name threadName = wide_thread_name;
+            ::LocalFree(wide_thread_name);
+            return threadName;
+         }
+
+         return native_thread_name();
+#else
+         // There is no way to get actual thread name size. At least 64 chars
+         // buffer required.
+         constexpr size_t kEstimateThreadNameSize{64};
+
+         native_thread_name threadName;
+         threadName.resize(kEstimateThreadNameSize);
+
+         // Linux, NetBSD, Mac OS X.
+         if (!::pthread_getname_np(handle, threadName.data(),
+                                   threadName.size())) {
+            const size_t terminatorIdx = threadName.find('\0');
+            if (terminatorIdx != std::string::npos) {
+               threadName.resize(terminatorIdx);
+            }
+         }
+
+         return threadName;
+#endif
+      }
+
+      void setThreadName(const native_thread_name &threadNamePrefix) {
+         static unsigned threadNo = 0;
+
+#ifdef WIN32
+         const native_thread_name threadName(threadNamePrefix + std::to_wstring(threadNo++));
+#else
+         const native_thread_name threadName(threadNamePrefix + std::to_string(threadNo++));
+#endif  // !WIN32
+   
+#ifdef WIN32
+         static auto setThreadDescription =
+            reinterpret_cast<HRESULT(WINAPI *)(HANDLE, PCWSTR)>(::GetProcAddress(
+               ::GetModuleHandleW(L"Kernel32.dll"), "SetThreadDescription"));
+         if (setThreadDescription == nullptr) {
+            return;
+         }
+
+         setThreadDescription(::GetCurrentThread(), threadName.c_str());
+#elif defined(__APPLE__)
+         // The thread name is a meaningful C language string, whose length is
+         // restricted to 64 characters, including the terminating null byte
+         // ('\0').
+         ::pthread_setname_np(threadName.c_str());
+#elif defined(__FreeBSD__)
+         ::pthread_set_name_np(::pthread_self(), threadName.c_str());
+#elif !defined(__Fuchsia__) && !defined(__EMSCRIPTEN__)
+         // The thread name is a meaningful C language string, whose length is
+         // restricted to 16 characters, including the terminating null byte
+         // ('\0').
+         ::pthread_setname_np(::pthread_self(), threadName.c_str());
+#else
+#error "Please define setThreadName for your platform."
+#endif  // !WIN32
+      }
+   }  // namespace internal
+}  // namespace kjellkod

--- a/src/g3log/active.hpp
+++ b/src/g3log/active.hpp
@@ -27,13 +27,28 @@
 namespace kjellkod {
    typedef std::function<void() > Callback;
 
+#ifdef WIN32
+   typedef std::wstring native_thread_name;
+   const inline native_thread_name DefaultThreadNamePrefix{L"G3log_Worker#"};
+#else
+   typedef std::string native_thread_name;
+   const inline native_thread_name DefaultThreadNamePrefix{"G3log_Worker#"};
+#endif  // !WIN32
+
+   namespace internal {
+      native_thread_name getThreadName(std::thread::native_handle_type handle);
+      void setThreadName(const native_thread_name &threadNamePrefix);
+   }
+
    class Active {
    private:
       Active() : done_(false) {} // Construction ONLY through factory createActive();
       Active(const Active &) = delete;
       Active &operator=(const Active &) = delete;
 
-      void run() {
+      void run(const native_thread_name &threadNamePrefix) {
+         internal::setThreadName(threadNamePrefix);
+
          while (!done_) {
             Callback func;
             mq_.wait_and_pop(func);
@@ -57,9 +72,10 @@ namespace kjellkod {
       }
 
       /// Factory: safe construction of object before thread start
-      static std::unique_ptr<Active> createActive() {
+      static std::unique_ptr<Active> createActive(
+         const native_thread_name &threadNamePrefix = DefaultThreadNamePrefix) {
          std::unique_ptr<Active> aPtr(new Active());
-         aPtr->thd_ = std::thread(&Active::run, aPtr.get());
+         aPtr->thd_ = std::thread(&Active::run, aPtr.get(), threadNamePrefix);
          return aPtr;
       }
    };

--- a/test_unit/Test.cmake
+++ b/test_unit/Test.cmake
@@ -66,7 +66,7 @@
         SET(OS_SPECIFIC_TEST test_crashhandler_windows)
      ENDIF(MSVC OR MINGW)
 
-      SET(tests_to_run test_message test_filechange test_io test_cpp_future_concepts test_concept_sink test_sink ${OS_SPECIFIC_TEST})
+      SET(tests_to_run test_message test_filechange test_io test_cpp_future_concepts test_concept_sink test_sink test_thread_name ${OS_SPECIFIC_TEST})
       SET(helper ${DIR_UNIT_TEST}/testing_helpers.h ${DIR_UNIT_TEST}/testing_helpers.cpp)
       include_directories(${DIR_UNIT_TEST})
 

--- a/test_unit/test_thread_name.cpp
+++ b/test_unit/test_thread_name.cpp
@@ -1,0 +1,75 @@
+/** ==========================================================================re
+ * 2011 by KjellKod.cc. This is PUBLIC DOMAIN to use at your own risk and comes
+ * with no warranties. This code is yours to share, use and modify with no
+ * strings attached and no restrictions or obligations.
+ *
+ * For more information see g3log/LICENSE or refer refer to http://unlicense.org
+ * ============================================================================*/
+
+#include <gtest/gtest.h>
+#include "g3log/active.hpp"
+
+#include <thread>
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <pthread.h>
+#endif
+
+namespace {
+   auto getCurrentThreadHandle() {
+#ifdef WIN32
+      return ::GetCurrentThread();
+#else
+      return ::pthread_self();
+#endif
+   }
+
+   template<typename THandle>
+   class ScopedThreadName {
+   public:
+      ScopedThreadName(THandle handle)
+         : old_thread_name_(kjellkod::internal::getThreadName(handle)) {
+      }
+      ~ScopedThreadName() {
+         kjellkod::internal::setThreadName(old_thread_name_);
+      }
+
+      ScopedThreadName(ScopedThreadName&) = delete;
+      ScopedThreadName(ScopedThreadName&&) = delete;
+
+      ScopedThreadName& operator=(ScopedThreadName&) = delete;
+      ScopedThreadName& operator=(ScopedThreadName&&) = delete;
+
+   private:
+      const kjellkod::native_thread_name old_thread_name_;
+   };
+}  // namespace
+
+#ifdef WIN32
+#define G3_NATIVE_THREAD_NAME(x) L##x
+#else
+#define G3_NATIVE_THREAD_NAME(x) x
+#endif
+
+TEST(ThreadNaming, GetSetThreadName) {
+   const auto currentThread = getCurrentThreadHandle();
+   const ScopedThreadName<std::decay_t<decltype(currentThread)>>
+      restore_original_thread_name(currentThread);
+
+   const kjellkod::native_thread_name newThreadName =
+      G3_NATIVE_THREAD_NAME("g3log test");
+
+   using namespace kjellkod::internal;
+
+   setThreadName(newThreadName);
+   // Append thread index.
+   EXPECT_EQ(newThreadName + G3_NATIVE_THREAD_NAME("0"),
+             getThreadName(currentThread));
+
+   setThreadName(newThreadName);
+   // Increment thread index on every attempt.
+   EXPECT_EQ(newThreadName + G3_NATIVE_THREAD_NAME("1"),
+             getThreadName(currentThread));
+}


### PR DESCRIPTION
# Allow to name g3log worker threads

Add names to g3log threads to simplify debugging (reasoning about what is this thread created for?)

By default `G3log_Worker#<thread no>`.

# Testing

- [x] This new/modified code was covered by unit tests. 

- [ ] (insight) Was all tests written using TDD (Test Driven Development) style?

- [x] The CI (Windows, Linux, OSX) are working without issues. 

- [ ] Was new functionality documented? 

- [x] The testing steps  1 - 2 below were followed

_step 1_

```bash 
mkdir build; cd build; cmake -DADD_G3LOG_UNIT_TEST=ON ..

// linux/osx alternative, simply run: ./scripts/buildAndRunTests.sh
```

_step 2: use one of these alternatives to run tests:_

- Cross-Platform: `ctest`
- or `ctest -V` for verbose output
- Linux: `make test`
