### PR TITLE
correcting and simplifying check for either Visual Studio or Windows

### DIFF
--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: ctest -C $BUILD_TYP
+        run: ctest -output-on-failure -C $BUILD_TYP
         
       - name: Fatal Exit Example Linux/OSX
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -63,7 +63,7 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: ls && cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DADD_G3LOG_UNIT_TEST=ON .. 
           
-      - name: Build Linux/OSx
+      - name: CMake build step
         working-directory: ${{github.workspace}}/build
         shell: bash
         run: cmake --build . --config $BUILD_TYPE
@@ -71,7 +71,7 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: ctest -output-on-failure -C $BUILD_TYP
+        run: ctest -verbose -C $BUILD_TYP
         
       - name: Fatal Exit Example Linux/OSX
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: ctest -verbose -C $BUILD_TYP
+        run: ctest --verbose -C $BUILD_TYP
         
       - name: Fatal Exit Example Linux/OSX
         working-directory: ${{github.workspace}}/build

--- a/src/logcapture.cpp
+++ b/src/logcapture.cpp
@@ -17,7 +17,7 @@
 // For Windows we need force a thread_local install per thread of three
 // signals that must have a signal handler installed per thread-basis
 // It is really a royal pain. Seriously Microsoft? Seriously?
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
+#if defined(_WIN32)
 #define SIGNAL_HANDLER_VERIFY() g3::installSignalHandlerForThread()
 #else
 // Does nothing  --- enforces that semicolon must be written
@@ -85,7 +85,8 @@ void LogCapture::capturef(const char* printf_like_message, ...) {
 #else
    static const int kMaxMessageSize = 2048;
    char finished_message[kMaxMessageSize];
-#if ((defined(WIN32) || defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__))
+// special handling for visual studio
+#if defined(_MSC_VER)
    auto finished_message_len = _countof(finished_message);
 #else
    int finished_message_len = sizeof(finished_message);
@@ -95,7 +96,7 @@ void LogCapture::capturef(const char* printf_like_message, ...) {
    va_list arglist;
    va_start(arglist, printf_like_message);
 
-#if ((defined(WIN32) || defined(_WIN32) || defined(__WIN32__)) && !defined(__GNUC__))
+#if defined(_MSC_VER)
    const int nbrcharacters = vsnprintf_s(finished_message, finished_message_len, _TRUNCATE, printf_like_message, arglist);
 #else
    const int nbrcharacters = vsnprintf(finished_message, finished_message_len, printf_like_message, arglist);


### PR DESCRIPTION
This PR simplifies the checking of when we are on the Windows platform 
Sometimes we want to check for Windows platform and sometimes if the build system is Visual Studio. 
Thanks to @kroeckx who called this out  https://github.com/KjellKod/g3log/issues/531