### PR TITLE
Issue #541 Linux: access to siginfo_t

### DIFF
--- a/src/crashhandler_unix.cpp
+++ b/src/crashhandler_unix.cpp
@@ -59,7 +59,7 @@ namespace {
    // Dump of stack,. then exit through g3log background worker
    // ALL thanks to this thread at StackOverflow. Pretty much borrowed from:
    // Ref: http://stackoverflow.com/questions/77005/how-to-generate-a-stacktrace-when-my-gcc-c-app-crashes
-   void signalHandler(int signal_number, siginfo_t* /*info*/, void* /*unused_context*/) {
+   void signalHandler(int signal_number, siginfo_t* info, void* /*unused_context*/) {
 
       using namespace g3::internal;
 
@@ -76,7 +76,7 @@ namespace {
          const auto fatal_reason = exitReasonName(g3::internal::FATAL_SIGNAL, signal_number);
          fatal_stream << "Received fatal signal: " << fatal_reason;
          fatal_stream << "(" << signal_number << ")\tPID: " << getpid() << std::endl;
-         fatal_stream << "\n***** SIGNAL " << fatal_reason << "(" << signal_number << ")" << std::endl;
+         fatal_stream << "\n***** SIGNAL " << fatal_reason << "(signo= " << signal_number << " si_errno= " << info->si_errno << " si_code = " << info->si_code << ")" << std::endl;
          LogCapture trigger(FATAL_SIGNAL, static_cast<g3::SignalType>(signal_number), dump.c_str());
          trigger.stream() << fatal_stream.str();
       }  // message sent to g3LogWorker


### PR DESCRIPTION
By using some informations located in siginfo_t for tracing, it remain accessible to be inspected by debugger even if the code compiled with optimisation flags (typically -O2).


# PULL REQUEST DESCRIPTION

`Issue 541 Linux: Access to siginfo_t`

# Formatting
- [x] I am following the formatting style of the existing codebase. 

# Testing

- [x] This new/modified code was covered by unit tests. 
- [ ] (insight) Was all tests written using TDD (Test Driven Development) style?
- [ ] The CI (Windows, Linux, OSX) are working without issues. 
- [ ] Was new functionality documented? 
- [x] The testing step 1 below was followed
- [ ] The testing step 2 below was followed

_step 1_

```bash 
linux/osx alternative, simply run: ./scripts/buildAndRunTests.sh
```

_step 2: use one of these alternatives to run tests:_

- Cross-Platform: `ctest`
- or `ctest -V` for verbose output
- Linux: `make test`
