### PR TITLE
Fix build for CMake >= 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 # Calculate the version number
 SET(MAJOR_VERSION 2)
-SET(MINOR_VERSION 4)
+SET(MINOR_VERSION 5)
 
 IF ( NOT VERSION )
    IF ( "${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows" )

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
# PULL REQUEST DESCRIPTION

Continues #546

I use CMake 4.0.2 and I cannot build the latest version (2.5):
```
$ cmake -S . -B build # more arguments
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
...
-- ******************** START *************************
// AUTO GENERATED MACRO DEFINITIONS FOR G3LOG


/** ==========================================================================
* 2015 by KjellKod.cc. This is PUBLIC DOMAIN to use at your own risk and comes
* with no warranties. This code is yours to share, use and modify with no
* strings attached and no restrictions or obligations.
*
* For more information see g3log/LICENSE or refer refer to http://unlicense.org
* ============================================================================*/

#pragma once


// CMake induced definitions below. See g3log/Options.cmake for details.


#define G3LOG_DEBUG DEBUG

-- ******************** END *************************
-- Creating g3log VERSION: 2.4-0
-- Creating g3log SOVERSION: 2
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Looking for backtrace
-- Looking for backtrace - found
-- backtrace facility detected in default set of libraries
-- Found Backtrace: /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include
-- Looking for abi::__cxa_demangle
-- Looking for abi::__cxa_demangle - found
-- -DADD_FATAL_EXAMPLE=ON
--              [contract][sigsegv][fatal choice] are examples of when g3log comes in handy

-- -DADD_G3LOG_BENCH_PERFORMANCE=OFF
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

This PR should fix this problem

# Formatting
- [ ] I am following the formatting style of the existing codebase. 

_a clang-format configuration file is available in the root of g3log._ 
- _Use VSCode with clang-formatter or commandline:_
`clang-format -i path_to_file` 
- _or recursive throughout the whole repo:_ `find . -iname "*.hpp" -o -iname "*.cpp" | xargs clang-format -i`


# Testing

- [ ] This new/modified code was covered by unit tests. 
- [ ] (insight) Was all tests written using TDD (Test Driven Development) style?
- [ ] The CI (Windows, Linux, OSX) are working without issues. 
- [ ] Was new functionality documented? 
- [ ] The testing steps  1 - 2 below were followed

_step 1_

```bash 
mkdir build; cd build; cmake -DADD_G3LOG_UNIT_TEST=ON ..

// linux/osx alternative, simply run: ./scripts/buildAndRunTests.sh
```

_step 2: use one of these alternatives to run tests:_

- Cross-Platform: `ctest`
- or `ctest -V` for verbose output
- Linux: `make test`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update CMake minimum required version to 3.5 to fix build issues with CMake >= 4.0.0 and increment project minor version.
> 
>   - **CMake Compatibility**:
>     - Update `cmake_minimum_required` from `2.8.2` to `3.5` in `CMakeLists.txt.in` to support CMake >= 4.0.0.
>   - **Versioning**:
>     - Increment `MINOR_VERSION` from `4` to `5` in `CMakeLists.txt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KjellKod%2Fg3log&utm_source=github&utm_medium=referral)<sup> for 1894b060b91fe5b43e3d5eb42f5395448e4a0e4a. You can [customize](https://app.ellipsis.dev/KjellKod/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->