### PR TITLE
Remove pessimizing move from sink future return

### DIFF
--- a/src/g3log/sinkhandle.hpp
+++ b/src/g3log/sinkhandle.hpp
@@ -44,7 +44,7 @@ namespace g3 {
             typedef std::invoke_result_t<decltype(func), T, Args...> PromiseType;
             std::promise<PromiseType> promise;
             promise.set_exception(std::make_exception_ptr(e));
-            return std::move(promise.get_future());
+            return promise.get_future();
          }
       }
 


### PR DESCRIPTION
## ⭐ Why this matters
Consumers compiling g3log with warnings treated as errors can currently fail on an unnecessary `std::move`, as reported in #564. This change restores clean compilation without changing future ownership or exception delivery.

---

## Summary
Return the temporary future directly from `SinkHandle::call()` so compilers can perform copy elision and avoid `-Wpessimizing-move`. Fixes #564.

## Changes
- Remove the unnecessary `std::move` around `promise.get_future()` in `src/g3log/sinkhandle.hpp`.
- Preserve the existing `std::bad_weak_ptr` exception path for expired sinks.

## Validation
- [x] Configure and build all targets with the warning promoted to an error: `cmake -S . -B build-issue-564 -DCMAKE_BUILD_TYPE=Release -DADD_G3LOG_UNIT_TEST=ON -DADD_G3LOG_BENCH_PERFORMANCE=ON -DPRETTY_FUNCTION=ON "-DCMAKE_CXX_FLAGS=-Wpessimizing-move -Werror=pessimizing-move" && cmake --build build-issue-564 --config Release --parallel`. Expected: the complete build succeeds without a pessimizing-move diagnostic.
- [x] Run `ctest --test-dir build-issue-564 -C Release --output-on-failure`. Expected: every discovered test passes; the current macOS/Linux suite reports 8/8 passing.

Watch for: `test_concept_sink` must continue delivering `std::bad_weak_ptr` through the returned future after its sink has expired.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest - https://github.com/KjellKod/Quest
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod
</pre>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/g3log/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

